### PR TITLE
chore: document feature branch workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git workflow
+
+**Always work on a feature branch — never commit directly to `main`.**
+
+Before starting any work, create a branch:
+```bash
+git checkout -b feat/<short-description>   # new feature
+git checkout -b fix/<short-description>    # bug fix
+git checkout -b chore/<short-description>  # tooling, deps, docs
+```
+
+When the work is done, push the branch and open a PR against `main`:
+```bash
+git push -u origin <branch-name>
+gh pr create --base main
+```
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a **Git workflow** section to `CLAUDE.md` documenting that all work should happen on a feature branch, never directly on `main`
- Covers branch naming convention (`feat/`, `fix/`, `chore/`) and the push + PR step

## Why

The previous session committed directly to `main`, which made it impossible to open a PR since there was no divergent branch. This documents the intended workflow so it doesn't happen again.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)