### PR TITLE
Remove recipes prop from RootLayout and ClientLayout

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -3,7 +3,6 @@
 import ToolBar from '@/components/ToolBar'
 import MarketingNav from '@/components/marketing/MarketingNav'
 import MarketingFooter from '@/components/marketing/MarketingFooter'
-import type { Recipe } from '@/types/Recipe'
 import { PrimeReactProvider } from 'primereact/api'
 import { SessionProvider } from 'next-auth/react'
 import { Analytics } from "@vercel/analytics/next"
@@ -11,7 +10,6 @@ import { SpeedInsights } from "@vercel/speed-insights/next"
 
 interface ClientLayoutProps {
   children: React.ReactNode
-  recipes: Recipe[]
   isLoggedIn: boolean
   username: string | null
   avatarUrl?: string | null

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,9 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import type { Metadata } from 'next'
 import ClientLayout from './ClientLayout'
-import { getRecipes } from '@/lib/recipes'
 import { auth } from '@/auth'
-import type { Recipe } from '@/types/Recipe'
 import 'primereact/resources/themes/lara-dark-blue/theme.css'
 import 'primereact/resources/primereact.min.css'
 import 'primeicons/primeicons.css';
@@ -24,8 +22,6 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const recipes: Recipe[] = await getRecipes()
-
   const session = await auth()
   const isLoggedIn = !!session?.user
   const username = session?.user?.name ?? null
@@ -38,7 +34,7 @@ export default async function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: `try{var t=localStorage.getItem('theme');if(t)document.documentElement.dataset.theme=t}catch(_){}` }} />
       </head>
       <body>
-        <ClientLayout recipes={recipes} isLoggedIn={isLoggedIn} username={username} avatarUrl={avatarUrl}>{children}</ClientLayout>
+        <ClientLayout isLoggedIn={isLoggedIn} username={username} avatarUrl={avatarUrl}>{children}</ClientLayout>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
Removes the `recipes` prop that was being fetched server-side in `RootLayout` and passed down to `ClientLayout`. This simplifies the layout component hierarchy by eliminating unnecessary prop drilling.

## Changes
- **app/layout.tsx**: Removed server-side `getRecipes()` call and `Recipe` type import from `RootLayout`
- **app/layout.tsx**: Removed `recipes` prop from `ClientLayout` component invocation
- **app/ClientLayout.tsx**: Removed `recipes: Recipe[]` from `ClientLayoutProps` interface

## Notes
This change assumes that recipes are now being fetched and managed elsewhere (likely in client-side stores or individual page components), aligning with the architecture pattern where `ClientLayout` focuses on layout concerns rather than data management.

https://claude.ai/code/session_01PQmdXTt2XbX9LCfwxg1kWC