### PR TITLE
feat: markdown recipe import with ingredient resolution and density propagation

### DIFF
--- a/scripts/backfill-usda-density.ts
+++ b/scripts/backfill-usda-density.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+/**
+ * Backfill density on USDA foods by fetching live portion data from the USDA API.
+ *
+ * The bulk CSV seed did not derive density from portion data. This script fetches
+ * each USDA food's full detail from FoodData Central (which includes volume portions)
+ * and runs mapPortionsToData to derive density. Safe to interrupt and re-run —
+ * already-updated foods are skipped.
+ *
+ * Usage:
+ *   bun --env-file .env.production scripts/backfill-usda-density.ts
+ *   bun --env-file .env.production scripts/backfill-usda-density.ts --dry-run
+ *   bun --env-file .env.production scripts/backfill-usda-density.ts --limit 50
+ *
+ * Rate: 1 request/second (3 600/hour — matches USDA API key limit).
+ * Expected runtime for ~8 000 foods: ~2.5 hours.
+ */
+
+import { parseArgs } from 'node:util'
+import { isNull, eq, and, isNotNull } from 'drizzle-orm'
+import { db } from '@/db'
+import { foods } from '@/db/schema'
+import { fetchFoodDetail, mapPortionsToData } from '@/lib/usda'
+
+// ── Args ──────────────────────────────────────────────────────────────────────
+
+const { values: args } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    'dry-run': { type: 'boolean', default: false },
+    limit: { type: 'string' },
+  },
+})
+
+const dryRun = args['dry-run']
+const limit = args.limit ? parseInt(args.limit, 10) : Infinity
+
+const DELAY_MS = 1000
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+// ── Query targets ─────────────────────────────────────────────────────────────
+
+console.log('\nQuerying USDA foods without density…')
+
+const targets = await db
+  .select({ id: foods.id, name: foods.name, externalId: foods.externalId })
+  .from(foods)
+  .where(
+    and(
+      isNull(foods.dateDeleted),
+      isNull(foods.density),
+      isNotNull(foods.externalId),
+    )
+  )
+  .then(rows => rows.filter(r => r.externalId != null))
+
+const toProcess = isFinite(limit) ? targets.slice(0, limit) : targets
+console.log(`  ${targets.length} total USDA foods need density`)
+if (isFinite(limit)) console.log(`  Processing first ${toProcess.length} (--limit ${limit})`)
+console.log(dryRun ? '  Dry run — no DB writes.\n' : '')
+
+// ── Process ───────────────────────────────────────────────────────────────────
+
+let updated = 0
+let noPortions = 0
+let noDensity = 0
+let errors = 0
+
+const startTime = Date.now()
+
+for (let i = 0; i < toProcess.length; i++) {
+  const row = toProcess[i]
+  const fdcId = parseInt(row.externalId!, 10)
+
+  // Progress line
+  const elapsed = Math.round((Date.now() - startTime) / 1000)
+  const eta = i > 0 ? Math.round(((Date.now() - startTime) / i) * (toProcess.length - i) / 1000) : '?'
+  process.stdout.write(
+    `\r  [${i + 1}/${toProcess.length}] elapsed=${elapsed}s eta=${eta}s  updated=${updated}  no-data=${noPortions + noDensity}  errors=${errors}  `
+  )
+
+  let detail
+  try {
+    detail = await fetchFoodDetail(fdcId)
+  } catch {
+    errors++
+    await sleep(DELAY_MS)
+    continue
+  }
+
+  if (!detail || !detail.foodPortions || detail.foodPortions.length === 0) {
+    noPortions++
+    await sleep(DELAY_MS)
+    continue
+  }
+
+  const { density } = mapPortionsToData(detail.foodPortions)
+
+  if (density == null || density <= 0) {
+    noDensity++
+    await sleep(DELAY_MS)
+    continue
+  }
+
+  if (!dryRun) {
+    await db.update(foods)
+      .set({ density: String(density), dateUpdated: new Date() })
+      .where(eq(foods.id, row.id))
+  }
+
+  updated++
+  await sleep(DELAY_MS)
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+const totalSeconds = Math.round((Date.now() - startTime) / 1000)
+const mins = Math.floor(totalSeconds / 60)
+const secs = totalSeconds % 60
+
+process.stdout.write('\n')
+console.log('\n─────────────────────────────')
+console.log(`  Processed: ${toProcess.length}`)
+console.log(dryRun ? `  Would update: ${updated}` : `  Updated:      ${updated}`)
+console.log(`  No portions:  ${noPortions}`)
+console.log(`  No density:   ${noDensity}  (portions exist but none are volume)`)
+console.log(`  Errors:       ${errors}`)
+console.log(`  Time:         ${mins}m ${secs}s`)
+console.log('─────────────────────────────')
+console.log('Done.\n')
+
+process.exit(0)

--- a/src/lib/recipes.ts
+++ b/src/lib/recipes.ts
@@ -40,6 +40,7 @@ function mapFood(row: typeof foods.$inferSelect): Food {
     servingSize: Number(row.servingSize ?? 1),
     servingUnit: row.servingUnit ?? 'g',
     measurements: parseMeasurements(row.measurements),
+    density: row.density != null ? Number(row.density) : undefined,
   }
 }
 
@@ -67,6 +68,7 @@ async function buildIngredients(recipeId: number): Promise<Ingredient[]> {
       targetAmount: quantity,
       targetUnit: servingUnit,
       gramsPerUnit: measurement?.gramsPerUnit,
+      density: food.density,
     }) ?? 0
     return { food, quantity, calories, servingUnit }
   })

--- a/src/lib/usda.ts
+++ b/src/lib/usda.ts
@@ -71,7 +71,7 @@ const USDA_UNIT_ALIASES: Record<string, string> = {
   mg: 'mg', milligram: 'mg', milligrams: 'mg',
 }
 
-function normaliseUSDAUnit(raw: string | undefined): string | null {
+export function normaliseUSDAUnit(raw: string | undefined): string | null {
   if (!raw) return null
   return USDA_UNIT_ALIASES[raw.toLowerCase().trim()] ?? null
 }
@@ -86,7 +86,9 @@ export function mapPortionsToData(portions: USDAFoodPortion[]): { measurements: 
     const amount = portion.amount ?? 1
     if (amount <= 0 || portion.gramWeight <= 0) continue
 
-    const rawUnit = portion.measureUnit?.abbreviation ?? portion.measureUnit?.name ?? portion.modifier
+    const unitFromMeasure = [portion.measureUnit?.abbreviation, portion.measureUnit?.name]
+      .find(v => v && v.trim() && v.toLowerCase().trim() !== 'undetermined')
+    const rawUnit = unitFromMeasure ?? portion.modifier
     if (!rawUnit?.trim()) continue
 
     const normUnit = normaliseUSDAUnit(rawUnit)

--- a/src/stores/recipes.ts
+++ b/src/stores/recipes.ts
@@ -91,6 +91,7 @@ export const useRecipeStore = create<RecipeStore>((set, get) => ({
                                   baseServingUnit,
                                   targetAmount: ingredient.quantity,
                                   targetUnit: newUnit,
+                                  density: food.density,
                                 })
 
                                 return {

--- a/src/utils/unitConversion.ts
+++ b/src/utils/unitConversion.ts
@@ -65,11 +65,7 @@ export function convertUnit({ value, fromUnit, toUnit, density }: { value: numbe
 export function getAllowedUnits(baseUnit: string, density?: number): string[] {
   const category = getUnitCategory(baseUnit)
   const hasDensity = density != null && density > 0
-  if(hasDensity) {
-    console.log(`Density is available: ${density}`)
-    console.log(`Base unit: ${baseUnit}, category: ${category}`)
-    console.log(`Allowed units: ${[...MASS_UNITS, ...VOLUME_UNITS]}`)
-  }
+
   if (category === 'mass') {
     return hasDensity ? [...MASS_UNITS, ...VOLUME_UNITS] : [...MASS_UNITS]
   }
@@ -98,15 +94,7 @@ export function calculateCalories({
   gramsPerUnit,
   density,
 }: CalculateCaloriesParams): number | null {
-  console.log('Calculating calories with params:', {
-    baseCalories,
-    baseServingSize,
-    baseServingUnit,
-    targetAmount,
-    targetUnit,
-    gramsPerUnit,
-    density,
-  })
+
   if (baseServingUnit === targetUnit) {
     return (baseCalories / baseServingSize) * targetAmount
   }

--- a/src/utils/unitConversion.ts
+++ b/src/utils/unitConversion.ts
@@ -65,7 +65,11 @@ export function convertUnit({ value, fromUnit, toUnit, density }: { value: numbe
 export function getAllowedUnits(baseUnit: string, density?: number): string[] {
   const category = getUnitCategory(baseUnit)
   const hasDensity = density != null && density > 0
-
+  if(hasDensity) {
+    console.log(`Density is available: ${density}`)
+    console.log(`Base unit: ${baseUnit}, category: ${category}`)
+    console.log(`Allowed units: ${[...MASS_UNITS, ...VOLUME_UNITS]}`)
+  }
   if (category === 'mass') {
     return hasDensity ? [...MASS_UNITS, ...VOLUME_UNITS] : [...MASS_UNITS]
   }
@@ -94,6 +98,15 @@ export function calculateCalories({
   gramsPerUnit,
   density,
 }: CalculateCaloriesParams): number | null {
+  console.log('Calculating calories with params:', {
+    baseCalories,
+    baseServingSize,
+    baseServingUnit,
+    targetAmount,
+    targetUnit,
+    gramsPerUnit,
+    density,
+  })
   if (baseServingUnit === targetUnit) {
     return (baseCalories / baseServingSize) * targetAmount
   }

--- a/src/views/Recipe/Index.tsx
+++ b/src/views/Recipe/Index.tsx
@@ -131,6 +131,7 @@ export default function Recipe({ recipe, foods = [], isEditing = false, canEdit 
       targetAmount: quantity,
       targetUnit: servingUnit,
       gramsPerUnit: measurement?.gramsPerUnit,
+      density: food.density,
     }) ?? 0
     return Math.round(raw)
   }

--- a/src/views/Recipe/Store.tsx
+++ b/src/views/Recipe/Store.tsx
@@ -83,6 +83,7 @@ function IngredientInput({ onAdd, onRemove, readOnly, storedIngredient }: { onAd
       baseServingUnit: ingredient.food?.servingUnit || DEFAULT_SERVING_UNIT,
       targetAmount: 1,
       targetUnit: ingredient.servingUnit,
+      density: ingredient.food?.density,
     }) || 0
     setIngredient({ ...ingredient, quantity, calories: caloriesPerUnit * quantity })
   }
@@ -102,6 +103,7 @@ function IngredientInput({ onAdd, onRemove, readOnly, storedIngredient }: { onAd
       baseServingUnit,
       targetAmount: ingredient.quantity,
       targetUnit: newUnit,
+      density: food.density,
     })
     
     // If conversion is possible, use calculated calories; otherwise keep current calories

--- a/src/views/Recipes/Index.tsx
+++ b/src/views/Recipes/Index.tsx
@@ -10,7 +10,7 @@ import { Checkbox } from 'primereact/checkbox'
 import { Toast } from 'primereact/toast'
 import { Skeleton } from 'primereact/skeleton'
 import RecipeCard from '@/components/RecipeCard/RecipeCard'
-import Link from '@/test/mocks/next-link'
+import Link from 'next/link'
 
 type SortOption = 'name' | 'date_added' | 'meal' | 'date_published'
 type SortDirection = 'asc' | 'desc'
@@ -209,7 +209,7 @@ export default function Recipes({ forYouRecipes = [], dietaryRestrictions = [], 
             )}
 
             { isAuthenticated && (
-              <Link href="/pantry/new" className="pill pill-primary">
+              <Link href="/recipes/new" className="pill pill-primary">
                 Add New
               </Link>
             )}

--- a/src/views/Recipes/Index.tsx
+++ b/src/views/Recipes/Index.tsx
@@ -10,6 +10,7 @@ import { Checkbox } from 'primereact/checkbox'
 import { Toast } from 'primereact/toast'
 import { Skeleton } from 'primereact/skeleton'
 import RecipeCard from '@/components/RecipeCard/RecipeCard'
+import Link from '@/test/mocks/next-link'
 
 type SortOption = 'name' | 'date_added' | 'meal' | 'date_published'
 type SortDirection = 'asc' | 'desc'
@@ -201,9 +202,16 @@ export default function Recipes({ forYouRecipes = [], dietaryRestrictions = [], 
             <h2 className="recipes-name">All Recipes</h2>
           </div>
           <div className="recipes-meta">
-            <span className="pill pill-primary">{recipes.length} recipes</span>
+            
+            <span className="pill">{recipes.length} recipes</span>
             {selectedRecipes.size > 0 && (
               <span className="pill pill-ghost">{selectedRecipes.size} selected</span>
+            )}
+
+            { isAuthenticated && (
+              <Link href="/pantry/new" className="pill pill-primary">
+                Add New
+              </Link>
             )}
           </div>
         </header>


### PR DESCRIPTION
## Summary

- Adds an **Advanced (markdown) import mode** to the recipe creation flow — paste freeform markdown and the importer parses ingredients via a custom CodeMirror language, resolves them against local foods (with LLM-assisted fallback), and lets you confirm matches before adding the recipe.
- Fixes **density not reaching the frontend** for recipe ingredients: `mapFood` in `src/lib/recipes.ts` was missing the `density` field, so cross-category unit conversion (e.g. cups of olive oil) silently fell back to same-category-only units on every recipe view.
- Adds a **USDA density backfill script** (`scripts/backfill-usda-density.ts`) to retroactively populate density on existing USDA-sourced foods, and wires density into the server-side calorie calculation in `buildIngredients`.
- Introduces **USDA food-name normalisation** via Claude at import time plus a Vercel daily cron (`/api/cron/normalize-usda-names`), with an ADR documenting the approach.

## What changed

- `src/views/Recipe/MarkdownImport.tsx` — new multi-step import UI (editor → candidates → confirm)
- `src/utils/recipeMarkdownParser.ts` — parser for the custom recipe markdown language
- `src/utils/recipeLanguage.ts` — CodeMirror grammar for syntax highlighting
- `app/api/recipes/import/resolve-ingredients/route.ts` — ingredient name resolution endpoint
- `src/lib/ai.ts` — hand-rolled Claude adapter (ADR 0016)
- `src/lib/recipes.ts` — `mapFood` now includes `density`; `buildIngredients` passes `density` to `calculateCalories`
- `src/lib/usda.ts` — density derivation from USDA portions
- `scripts/backfill-usda-density.ts` — one-shot backfill script

## Reviewer notes

- The cron route requires a `CRON_SECRET` env var; it's guarded by bearer-token auth.
- The resolve-ingredients route calls Claude — ensure `ANTHROPIC_API_KEY` is set in the deployment environment.
- The density fix is a silent correctness bug: no UI changes, but volume-unit dropdowns on recipe ingredients now correctly reflect whether mass↔volume conversion is available.

## Test plan

- [ ] Paste a markdown recipe in the Advanced import tab and verify ingredients resolve and match correctly
- [ ] Confirm a food with `density` set shows volume units in the ingredient unit dropdown on the recipe page
- [ ] Run `bun run test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)