### PR TITLE
feat: USDA Branded bulk import and AI-assisted product–food linker

### DIFF
--- a/docs/adr/0019-usda-branded-import-two-pass-ai-linking.md
+++ b/docs/adr/0019-usda-branded-import-two-pass-ai-linking.md
@@ -4,7 +4,7 @@
 Accepted
 
 ## Context
-Products can optionally carry a `parentFoodId` linking them to a generic Food. This link enables recipe nutrition tracking when a user adds a branded Product to their pantry — the system uses the parent Food's per-100g nutrition data. Without the link, a Product in the pantry contributes nothing to recipe suggestions.
+Products can optionally carry a `parentFoodId` linking them to a generic Food. This link enables recipe nutrition tracking when a user adds a branded Product to their pantry — the system uses the parent Food's per-100g nutrition data. Without the link, a Product can still be tracked in the pantry but may not contribute to recipe-level nutrition calculations.
 
 Importing USDA Branded Foods from the FDC Full Download CSV creates hundreds of thousands of Product rows. Each row needs a `parentFoodId` resolved from the existing `foods` table (Foundation/SR Legacy Foods). The match is non-trivial: a branded name like `"TYSON, Boneless Skinless Chicken Breast, 3 lb"` must map to a canonical Food like `"Chicken Breast (boneless, skinless, raw)"`.
 
@@ -36,6 +36,5 @@ The linker applies to all unlinked Products regardless of source (`usda_branded`
 ## Consequences
 
 - The `products` table will have a period where newly imported rows have `parentFoodId = null`. This is acceptable — the link is optional by design and pantry tracking works without it.
-- Running the linker on Open Food Facts products may yield fewer matches (noisier names) but will not produce incorrect links — the LLM returns `"none"` when confidence is low.
+- Running the linker on Open Food Facts products may yield fewer matches (noisier names). The LLM is prompted to return `"none"` when confidence is low, which minimises incorrect links, though LLM output is not guaranteed to be error-free. The dry-run flag exists precisely to allow human review before committing results at scale.
 - LLM costs are bounded by the number of unlinked Products that have at least one candidate Food in the DB (zero-candidate rows are fast-pathed without an LLM call).
-- The dry-run flag makes it safe to preview AI decisions before a production linking run.

--- a/docs/adr/0019-usda-branded-import-two-pass-ai-linking.md
+++ b/docs/adr/0019-usda-branded-import-two-pass-ai-linking.md
@@ -1,0 +1,41 @@
+# ADR 0019: Two-pass approach for USDA Branded Product import with AI-assisted parent Food linking
+
+## Status
+Accepted
+
+## Context
+Products can optionally carry a `parentFoodId` linking them to a generic Food. This link enables recipe nutrition tracking when a user adds a branded Product to their pantry — the system uses the parent Food's per-100g nutrition data. Without the link, a Product in the pantry contributes nothing to recipe suggestions.
+
+Importing USDA Branded Foods from the FDC Full Download CSV creates hundreds of thousands of Product rows. Each row needs a `parentFoodId` resolved from the existing `foods` table (Foundation/SR Legacy Foods). The match is non-trivial: a branded name like `"TYSON, Boneless Skinless Chicken Breast, 3 lb"` must map to a canonical Food like `"Chicken Breast (boneless, skinless, raw)"`.
+
+## Considered Options
+
+**Inline linking during import:** Each Product row is linked to its parent Food as it is inserted — one LLM call per product during the CSV import pass.
+
+- Fast to implement, single script.
+- Blocks the import on LLM rate limits and API cost at scale (potentially hundreds of thousands of calls in a single run).
+- A transient LLM failure or budget exhaustion would halt the import mid-stream, leaving a partially-imported dataset.
+
+**Two-pass: import then link (chosen):** A fast, deterministic import script writes Products with `parentFoodId = null`. A separate linker script runs afterward and resolves links incrementally.
+
+- The import is fast, idempotent, and never blocked by LLM availability.
+- The linker is independently re-runnable, can be rate-limited, and skips already-linked rows (`parentFoodId IS NOT NULL`).
+- Dry-run mode on the linker allows review of AI decisions before committing at scale.
+- Matches the precedent set by `normalize-usda-food-names.ts` (import fast, enrich separately).
+
+## Decision
+
+Use two scripts:
+
+1. **`scripts/seed-usda-branded.ts`** — streams the FDC Branded CSV files, filters to cooking-relevant `branded_food_category` values, and upserts rows into `products` with `parentFoodId = null`. Re-runnable; upserts on `externalId`.
+
+2. **`scripts/link-product-foods.ts`** — processes all Products where `parentFoodId IS NULL`. For each, it strips the brand owner and weight/unit suffixes from the product name, runs an `ilike` search against `foods` to find up to 5 candidates, then passes the branded name and candidates to Claude Haiku to pick the best match or return `"none"`. Writes `parentFoodId` on a match; leaves null on `"none"` or zero candidates. Supports `--dry-run` to print decisions without writing. Re-runnable and incremental.
+
+The linker applies to all unlinked Products regardless of source (`usda_branded`, `open_food_facts`, `manual`), so it serves as a general-purpose parent-linking tool, not just a post-import step.
+
+## Consequences
+
+- The `products` table will have a period where newly imported rows have `parentFoodId = null`. This is acceptable — the link is optional by design and pantry tracking works without it.
+- Running the linker on Open Food Facts products may yield fewer matches (noisier names) but will not produce incorrect links — the LLM returns `"none"` when confidence is low.
+- LLM costs are bounded by the number of unlinked Products that have at least one candidate Food in the DB (zero-candidate rows are fast-pathed without an LLM call).
+- The dry-run flag makes it safe to preview AI decisions before a production linking run.

--- a/scripts/link-product-foods.ts
+++ b/scripts/link-product-foods.ts
@@ -42,8 +42,20 @@ const { values: args } = parseArgs({
 })
 
 const DRY_RUN = args['dry-run'] ?? false
-const LIMIT = args.limit ? parseInt(args.limit, 10) : DEFAULT_LIMIT
-const CONCURRENCY = args.concurrency ? parseInt(args.concurrency, 10) : DEFAULT_CONCURRENCY
+
+const rawLimit = args.limit ? parseInt(args.limit, 10) : NaN
+if (args.limit && (isNaN(rawLimit) || rawLimit <= 0)) {
+  console.error(`Error: --limit must be a positive integer (got "${args.limit}")`)
+  process.exit(1)
+}
+const LIMIT = isNaN(rawLimit) ? DEFAULT_LIMIT : rawLimit
+
+const rawConcurrency = args.concurrency ? parseInt(args.concurrency, 10) : NaN
+if (args.concurrency && (isNaN(rawConcurrency) || rawConcurrency <= 0)) {
+  console.error(`Error: --concurrency must be a positive integer (got "${args.concurrency}")`)
+  process.exit(1)
+}
+const CONCURRENCY = isNaN(rawConcurrency) ? DEFAULT_CONCURRENCY : rawConcurrency
 
 if (DRY_RUN) console.log('\n⚠  DRY RUN — no writes will be made\n')
 
@@ -138,14 +150,14 @@ function chunk<T>(arr: T[], size: number): T[][] {
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 console.log('\nQuerying unlinked products…')
-const unlinked = await db
+const baseQuery = db
   .select({ id: products.id, name: products.name, source: products.source })
   .from(products)
   .where(and(isNull(products.parentFoodId), isNull(products.dateDeleted)))
 
-const toProcess = unlinked.slice(0, LIMIT)
-console.log(`  ${unlinked.length.toLocaleString()} unlinked products total`)
-if (LIMIT < Infinity) console.log(`  Processing first ${LIMIT.toLocaleString()} (--limit)`)
+const toProcess = await (LIMIT < Infinity ? baseQuery.limit(LIMIT) : baseQuery)
+console.log(`  ${toProcess.length.toLocaleString()} unlinked products to process`)
+if (LIMIT < Infinity) console.log(`  Limited to first ${LIMIT.toLocaleString()} (--limit)`)
 console.log(`  Concurrency: ${CONCURRENCY}`)
 console.log()
 

--- a/scripts/link-product-foods.ts
+++ b/scripts/link-product-foods.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env bun
+/**
+ * Link Products to their parent Foods using AI-assisted matching.
+ *
+ * Usage:
+ *   bun --env-file .env.local scripts/link-product-foods.ts
+ *   bun --env-file .env.local scripts/link-product-foods.ts --dry-run
+ *   bun --env-file .env.local scripts/link-product-foods.ts --limit 500 --concurrency 10
+ *
+ * For each unlinked Product (parentFoodId IS NULL):
+ *   1. Preprocess the product name (strip brand prefix and weight suffixes)
+ *   2. Search the foods table for up to MAX_CANDIDATES matches
+ *   3. If no candidates: skip (fast-path, no LLM call)
+ *   4. If candidates: ask Claude Haiku to pick the best match or return "none"
+ *   5. Write parentFoodId on a match (unless --dry-run)
+ *
+ * Re-runnable: already-linked products (parentFoodId IS NOT NULL) are skipped.
+ * Applies to all Products regardless of source (usda_branded, open_food_facts, manual).
+ */
+
+import { parseArgs } from 'node:util'
+import { and, isNull, ilike, isNotNull, eq } from 'drizzle-orm'
+import { db } from '@/db'
+import { products, foods } from '@/db/schema'
+import { complete, Models, AIBudgetExhaustedError } from '@/lib/ai'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const MAX_CANDIDATES = 5
+const DEFAULT_CONCURRENCY = 5
+const DEFAULT_LIMIT = Infinity
+
+// ── CLI args ──────────────────────────────────────────────────────────────────
+
+const { values: args } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    'dry-run':   { type: 'boolean', default: false },
+    limit:       { type: 'string' },
+    concurrency: { type: 'string' },
+  },
+})
+
+const DRY_RUN = args['dry-run'] ?? false
+const LIMIT = args.limit ? parseInt(args.limit, 10) : DEFAULT_LIMIT
+const CONCURRENCY = args.concurrency ? parseInt(args.concurrency, 10) : DEFAULT_CONCURRENCY
+
+if (DRY_RUN) console.log('\n⚠  DRY RUN — no writes will be made\n')
+
+// ── Name preprocessing ────────────────────────────────────────────────────────
+
+// Trailing weight/count patterns: "3 LB", "12OZ", "500G", "2 CT", "1.5 KG", "250 ML"
+const WEIGHT_SUFFIX_RE = /[\s,]+[\d.]+\s*(?:fl\.?\s*oz|fluid\s*ounces?|gallons?|liters?|litres?|milliliters?|millilitres?|ml|oz|lbs?|kg|g\b|ct|pk|packs?|count)\b\.?/gi
+
+// USDA-style brand prefix: uppercase word(s) before the first comma
+// e.g. "TYSON, CHICKEN BREAST" → "CHICKEN BREAST"
+// Requires at least 2 chars before the comma to avoid stripping initials like "A,"
+const BRAND_PREFIX_RE = /^[A-Z][A-Z\s&'.]{1,}\s*,\s*/
+
+function preprocessName(name: string): string {
+  let cleaned = name.replace(WEIGHT_SUFFIX_RE, ' ')
+  cleaned = cleaned.replace(BRAND_PREFIX_RE, '')
+  return cleaned.replace(/\s+/g, ' ').trim()
+}
+
+// ── Candidate search ──────────────────────────────────────────────────────────
+
+async function findCandidates(cleanedName: string): Promise<{ id: number; name: string }[]> {
+  const candidates = await db
+    .select({ id: foods.id, name: foods.name })
+    .from(foods)
+    .where(and(isNull(foods.dateDeleted), ilike(foods.name, `%${cleanedName}%`)))
+    .limit(MAX_CANDIDATES)
+
+  if (candidates.length > 0) return candidates
+
+  // Fallback: try first two content words if the full name matched nothing
+  const firstWords = cleanedName.split(/\s+/).slice(0, 2).join(' ')
+  if (firstWords.length < 3) return []
+
+  return db
+    .select({ id: foods.id, name: foods.name })
+    .from(foods)
+    .where(and(isNull(foods.dateDeleted), ilike(foods.name, `%${firstWords}%`)))
+    .limit(MAX_CANDIDATES)
+}
+
+// ── AI linking ────────────────────────────────────────────────────────────────
+
+const LINK_SYSTEM_PROMPT = `You are a food classifier. Given a branded product name, select the best matching generic food from a numbered list of candidates.
+
+Output ONLY the numeric ID of the best match, or the word "none" if no candidate is a reasonable match. No explanation, no punctuation, no extra text.
+
+Rules:
+- Match on the core food item, ignoring brand name, flavoring, and package size
+- A match is appropriate when the branded product is a specific version of the generic food
+- Output "none" when no candidate is a close match or the product is a supplement, pet food, or non-food item
+
+Examples:
+Product "Tyson Boneless Skinless Chicken Breast" + candidates including "Chicken Breast (boneless, skinless, raw)" → output: 42
+Product "Kind Dark Chocolate Nuts & Sea Salt Bar" + no close food match → output: none`
+
+async function pickBestFood(
+  productName: string,
+  candidates: { id: number; name: string }[],
+): Promise<number | null> {
+  const userMessage = [
+    `<product_name>${productName}</product_name>`,
+    '<candidates>',
+    candidates.map(c => `${c.id}: ${c.name}`).join('\n'),
+    '</candidates>',
+  ].join('\n')
+
+  const response = await complete({
+    systemPrompt: LINK_SYSTEM_PROMPT,
+    userMessage,
+    aiModel: Models.anthropicHaiku,
+  })
+
+  const trimmed = response.trim().toLowerCase()
+  if (trimmed === 'none' || trimmed === '') return null
+
+  const parsed = parseInt(response.trim(), 10)
+  if (isNaN(parsed)) return null
+
+  // Validate the returned ID is actually in our candidate list
+  return candidates.some(c => c.id === parsed) ? parsed : null
+}
+
+// ── Batch helpers ─────────────────────────────────────────────────────────────
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+console.log('\nQuerying unlinked products…')
+const unlinked = await db
+  .select({ id: products.id, name: products.name, source: products.source })
+  .from(products)
+  .where(and(isNull(products.parentFoodId), isNull(products.dateDeleted)))
+
+const toProcess = unlinked.slice(0, LIMIT)
+console.log(`  ${unlinked.length.toLocaleString()} unlinked products total`)
+if (LIMIT < Infinity) console.log(`  Processing first ${LIMIT.toLocaleString()} (--limit)`)
+console.log(`  Concurrency: ${CONCURRENCY}`)
+console.log()
+
+let linked = 0
+let skippedNoCandidates = 0
+let skippedNoMatch = 0
+let errors = 0
+let processed = 0
+
+type Result = { productId: number; foodId: number | null; productName: string; foodName: string | null; reason: 'linked' | 'no-candidates' | 'no-match' | 'error' }
+
+async function processProduct(product: { id: number; name: string; source: string }): Promise<Result> {
+  const cleanedName = preprocessName(product.name)
+
+  if (cleanedName.length < 2) {
+    return { productId: product.id, foodId: null, productName: product.name, foodName: null, reason: 'no-candidates' }
+  }
+
+  let candidates: { id: number; name: string }[]
+  try {
+    candidates = await findCandidates(cleanedName)
+  } catch {
+    return { productId: product.id, foodId: null, productName: product.name, foodName: null, reason: 'error' }
+  }
+
+  if (candidates.length === 0) {
+    return { productId: product.id, foodId: null, productName: product.name, foodName: null, reason: 'no-candidates' }
+  }
+
+  let foodId: number | null
+  try {
+    foodId = await pickBestFood(product.name, candidates)
+  } catch (err) {
+    if (err instanceof AIBudgetExhaustedError) throw err
+    return { productId: product.id, foodId: null, productName: product.name, foodName: null, reason: 'error' }
+  }
+
+  if (foodId === null) {
+    return { productId: product.id, foodId: null, productName: product.name, foodName: null, reason: 'no-match' }
+  }
+
+  const matchedFood = candidates.find(c => c.id === foodId)!
+  return { productId: product.id, foodId, productName: product.name, foodName: matchedFood.name, reason: 'linked' }
+}
+
+// Process in concurrent batches
+for (const batch of chunk(toProcess, CONCURRENCY)) {
+  let results: Result[]
+  try {
+    results = await Promise.all(batch.map(p => processProduct(p)))
+  } catch (err) {
+    if (err instanceof AIBudgetExhaustedError) {
+      console.error('\n✗ AI budget exhausted — stopping. Results so far will be committed.')
+      break
+    }
+    throw err
+  }
+
+  for (const result of results) {
+    processed++
+
+    if (result.reason === 'linked') {
+      if (DRY_RUN) {
+        console.log(`  [DRY] "${result.productName}" → "${result.foodName}" (food #${result.foodId})`)
+      } else {
+        await db.update(products)
+          .set({ parentFoodId: result.foodId, dateUpdated: new Date() })
+          .where(eq(products.id, result.productId))
+      }
+      linked++
+    } else if (result.reason === 'no-candidates') {
+      skippedNoCandidates++
+    } else if (result.reason === 'no-match') {
+      skippedNoMatch++
+    } else {
+      errors++
+    }
+  }
+
+  process.stdout.write(
+    `\r  ${processed.toLocaleString()} / ${toProcess.length.toLocaleString()} — linked: ${linked}, no-candidates: ${skippedNoCandidates}, no-match: ${skippedNoMatch}, errors: ${errors}  `
+  )
+}
+
+process.stdout.write('\n')
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log('\n─────────────────────────────────────────')
+if (DRY_RUN) console.log('  DRY RUN — nothing written')
+console.log(`  Processed:      ${processed.toLocaleString()}`)
+console.log(`  Linked:         ${linked.toLocaleString()}`)
+console.log(`  No candidates:  ${skippedNoCandidates.toLocaleString()}`)
+console.log(`  No match (LLM): ${skippedNoMatch.toLocaleString()}`)
+console.log(`  Errors:         ${errors}`)
+console.log('─────────────────────────────────────────\n')
+
+process.exit(0)

--- a/scripts/link-product-foods.ts
+++ b/scripts/link-product-foods.ts
@@ -19,7 +19,7 @@
  */
 
 import { parseArgs } from 'node:util'
-import { and, isNull, ilike, isNotNull, eq } from 'drizzle-orm'
+import { and, isNull, ilike, eq } from 'drizzle-orm'
 import { db } from '@/db'
 import { products, foods } from '@/db/schema'
 import { complete, Models, AIBudgetExhaustedError } from '@/lib/ai'

--- a/scripts/seed-usda-branded.ts
+++ b/scripts/seed-usda-branded.ts
@@ -391,7 +391,7 @@ function buildValues(fdcId: string, meta: BrandedMeta): ProductValues {
   // slug: leave room for -fdcId suffix (fdcIds up to 8 digits + hyphen = 9 chars)
   const baseSlug = toSlug(name).slice(0, 245)
   const slug = takenSlugs.has(baseSlug) ? `${baseSlug}-${fdcId}` : baseSlug
-  takenSlugs.add(slug)
+  // takenSlugs.add() is intentionally omitted here — caller reserves the slug only for inserts
 
   // Clamp all numeric fields to their DB column limits.
   // Bad data in the CSV (e.g. absurd bulk serving sizes) is safer to cap than crash.
@@ -437,7 +437,9 @@ for (const [fdcId, meta] of targetBranded) {
     const { slug: _slug, source: _src, parentFoodId: _pid, ...updateFields } = buildValues(fdcId, meta)
     toUpdate.push({ id: existing.id, values: updateFields })
   } else {
-    toInsert.push(buildValues(fdcId, meta))
+    const values = buildValues(fdcId, meta)
+    takenSlugs.add(values.slug!)
+    toInsert.push(values)
   }
 }
 

--- a/scripts/seed-usda-branded.ts
+++ b/scripts/seed-usda-branded.ts
@@ -1,0 +1,486 @@
+#!/usr/bin/env bun
+/**
+ * Seed USDA Branded Foods from FDC Full Download CSV files into the products table.
+ *
+ * Usage:
+ *   bun --env-file .env.local scripts/seed-usda-branded.ts --dir ./data/usda
+ *
+ * Expects the FDC Full Download CSV files in --dir:
+ *   food.csv, food_nutrient.csv, food_portion.csv, measure_unit.csv, branded_food.csv
+ *
+ * Only rows whose branded_food_category matches ALLOWED_CATEGORY_SUBSTRINGS are imported.
+ * Products are inserted with parentFoodId = null — run link-product-foods.ts afterward.
+ *
+ * Re-runnable: existing products (matched by externalId / fdcId) are updated in place.
+ */
+
+import { parseArgs } from 'node:util'
+import { readFileSync, existsSync, createReadStream } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { createInterface } from 'node:readline'
+import { eq } from 'drizzle-orm'
+import { db } from '@/db'
+import { products } from '@/db/schema'
+import type { Measurement } from '@/types/Food'
+import { toSlug } from '@/utils/slug'
+
+// ── Nutrient IDs (FDC standard) ───────────────────────────────────────────────
+
+const NID = {
+  energy:  '1008', // kcal
+  protein: '1003', // g
+  carbs:   '1005', // g
+  fat:     '1004', // g
+  fiber:   '1079', // g
+  satFat:  '1258', // g
+  sugar:   '2000', // g
+  sodium:  '1093', // mg
+} as const
+
+// ── Category allowlist ────────────────────────────────────────────────────────
+// A branded product is imported only when its branded_food_category contains at
+// least one of these substrings (case-insensitive). Edit freely.
+
+const ALLOWED_CATEGORY_SUBSTRINGS = [
+  // Meat & poultry
+  'poultry', 'chicken', 'turkey', 'duck',
+  'beef', 'pork', 'lamb', 'veal', 'game', 'bison',
+  'sausage', 'luncheon', 'deli', 'hot dog', 'bacon', 'ham',
+  // Seafood
+  'seafood', 'fish', 'shellfish', 'shrimp', 'salmon', 'tuna', 'crab', 'lobster',
+  // Dairy & eggs
+  'dairy', 'cheese', 'milk', 'butter', 'cream', 'yogurt', 'egg',
+  // Produce
+  'vegetable', 'produce', 'fruit', 'juice',
+  // Grains & baked
+  'bread', 'baked', 'grain', 'pasta', 'cereal', 'rice', 'flour', 'tortilla',
+  // Nuts, seeds, legumes
+  'nut', 'seed', 'legume', 'bean', 'lentil', 'tofu', 'soy',
+  // Fats & condiments
+  'fat', 'oil', 'dressing', 'sauce', 'soup', 'gravy', 'condiment',
+  'spice', 'herb', 'seasoning', 'vinegar', 'mustard', 'ketchup', 'mayo',
+  // Snacks & sweets
+  'snack', 'chip', 'cracker', 'pretzel', 'popcorn',
+  'sweet', 'candy', 'chocolate', 'dessert', 'cookie', 'cake', 'ice cream',
+  // Frozen & prepared
+  'frozen', 'meal', 'entree', 'pizza', 'dinner', 'breakfast',
+  // Beverages
+  'beverage', 'drink', 'water', 'coffee', 'tea', 'soda', 'smoothie',
+]
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const INSERT_CHUNK = 200
+const UPDATE_CONCURRENCY = 20
+const REQUIRED_FILES = [
+  'food.csv', 'food_nutrient.csv', 'food_portion.csv',
+  'measure_unit.csv', 'branded_food.csv',
+]
+
+// ── CSV helpers ───────────────────────────────────────────────────────────────
+
+function parseFields(line: string): string[] {
+  const fields: string[] = []
+  let i = 0
+  while (i < line.length) {
+    if (line[i] === '"') {
+      let val = ''
+      i++
+      while (i < line.length) {
+        if (line[i] === '"' && line[i + 1] === '"') { val += '"'; i += 2 }
+        else if (line[i] === '"') { i++; break }
+        else { val += line[i++] }
+      }
+      fields.push(val)
+      if (i < line.length && line[i] === ',') i++
+    } else {
+      const end = line.indexOf(',', i)
+      if (end === -1) { fields.push(line.slice(i)); break }
+      fields.push(line.slice(i, end))
+      i = end + 1
+    }
+  }
+  if (line.endsWith(',')) fields.push('')
+  return fields
+}
+
+function parseCSV(raw: string): Record<string, string>[] {
+  const lines = raw.split('\n')
+  if (lines.length === 0) return []
+  const headers = parseFields(lines[0].replace(/\r$/, ''))
+  const result: Record<string, string>[] = []
+  for (let r = 1; r < lines.length; r++) {
+    const line = lines[r].replace(/\r$/, '')
+    if (!line.trim()) continue
+    const fields = parseFields(line)
+    const row: Record<string, string> = {}
+    for (let c = 0; c < headers.length; c++) row[headers[c]] = fields[c] ?? ''
+    result.push(row)
+  }
+  return result
+}
+
+async function* streamCSVRows(filePath: string): AsyncGenerator<Record<string, string>> {
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: 'utf-8' }),
+    crlfDelay: Infinity,
+  })
+  let headers: string[] | null = null
+  for await (const rawLine of rl) {
+    const line = rawLine.replace(/\r$/, '')
+    if (!line.trim()) continue
+    if (headers === null) { headers = parseFields(line); continue }
+    const fields = parseFields(line)
+    const row: Record<string, string> = {}
+    for (let i = 0; i < headers.length; i++) row[headers[i]] = fields[i] ?? ''
+    yield row
+  }
+}
+
+// ── Batch helpers ─────────────────────────────────────────────────────────────
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+async function runConcurrently<T>(tasks: (() => Promise<T>)[], concurrency: number): Promise<T[]> {
+  const results: T[] = []
+  for (const batch of chunk(tasks, concurrency)) {
+    results.push(...(await Promise.all(batch.map(t => t()))))
+  }
+  return results
+}
+
+function progress(label: string, done: number, total: number) {
+  const pct = Math.round((done / total) * 100)
+  process.stdout.write(`\r  ${label}: ${done.toLocaleString()} / ${total.toLocaleString()} (${pct}%)  `)
+}
+
+// ── Volume unit → ml factors (for density derivation) ────────────────────────
+
+const VOLUME_TO_ML: Record<string, number> = {
+  ml: 1, milliliter: 1, milliliters: 1, millilitre: 1, millilitres: 1,
+  l: 1000, liter: 1000, liters: 1000, litre: 1000, litres: 1000,
+  cup: 236.588, cups: 236.588,
+  tbsp: 14.787, tbs: 14.787, tablespoon: 14.787, tablespoons: 14.787,
+  tsp: 4.929, teaspoon: 4.929, teaspoons: 4.929,
+  'fl oz': 29.574, 'fl-oz': 29.574, 'fluid ounce': 29.574, 'fluid ounces': 29.574,
+}
+
+// ── Unit normalisation ────────────────────────────────────────────────────────
+
+const UNIT_ALIASES: Record<string, string> = {
+  cup: 'cup', cups: 'cup',
+  tbsp: 'Tbs', tbs: 'Tbs', tablespoon: 'Tbs', tablespoons: 'Tbs',
+  tsp: 'tsp', teaspoon: 'tsp', teaspoons: 'tsp',
+  'fl oz': 'fl-oz', 'fl-oz': 'fl-oz',
+  ml: 'ml', milliliter: 'ml', milliliters: 'ml', millilitre: 'ml', millilitres: 'ml',
+  l: 'l', liter: 'l', liters: 'l', litre: 'l', litres: 'l',
+  g: 'g', gram: 'g', grams: 'g',
+  kg: 'kg', kilogram: 'kg', kilograms: 'kg',
+  oz: 'oz', ounce: 'oz', ounces: 'oz',
+  lb: 'lb', pound: 'lb', pounds: 'lb',
+  mg: 'mg', milligram: 'mg', milligrams: 'mg',
+}
+
+function normaliseUnit(raw: string | undefined): string | null {
+  if (!raw) return null
+  return UNIT_ALIASES[raw.toLowerCase().trim()] ?? null
+}
+
+// ── Category check ────────────────────────────────────────────────────────────
+
+function isAllowedCategory(category: string): boolean {
+  const lower = category.toLowerCase()
+  return ALLOWED_CATEGORY_SUBSTRINGS.some(s => lower.includes(s))
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+const { values: args } = parseArgs({
+  args: process.argv.slice(2),
+  options: { dir: { type: 'string' } },
+})
+
+if (!args.dir) {
+  console.error('Usage: bun --env-file .env.local scripts/seed-usda-branded.ts --dir ./data/usda')
+  process.exit(1)
+}
+
+const dir = resolve(args.dir)
+for (const f of REQUIRED_FILES) {
+  if (!existsSync(join(dir, f))) {
+    console.error(`Missing required file: ${join(dir, f)}`)
+    process.exit(1)
+  }
+}
+
+// ── Step 1: Read small reference files into memory ────────────────────────────
+
+console.log('\nReading reference files…')
+const measureUnits = new Map(
+  parseCSV(readFileSync(join(dir, 'measure_unit.csv'), 'utf-8')).map(r => [r.id, r.name])
+)
+const portionRows = parseCSV(readFileSync(join(dir, 'food_portion.csv'), 'utf-8'))
+console.log(`  measure_unit.csv: ${measureUnits.size} units`)
+console.log(`  food_portion.csv: ${portionRows.length.toLocaleString()} rows`)
+
+// ── Step 2: Stream branded_food.csv to collect target products ────────────────
+
+interface BrandedMeta {
+  brandOwner: string
+  barcode: string
+  servingSize: number
+  servingUnit: string
+  category: string
+}
+
+console.log('\nStreaming branded_food.csv…')
+const targetBranded = new Map<string, BrandedMeta>()
+let totalBrandedRows = 0
+let skippedCategory = 0
+
+for await (const row of streamCSVRows(join(dir, 'branded_food.csv'))) {
+  totalBrandedRows++
+  if (totalBrandedRows % 100000 === 0) {
+    process.stdout.write(`\r  scanned ${totalBrandedRows.toLocaleString()} rows, accepted ${targetBranded.size.toLocaleString()}…`)
+  }
+
+  const category = row.branded_food_category ?? ''
+  if (!isAllowedCategory(category)) { skippedCategory++; continue }
+
+  const rawServingSize = parseFloat(row.serving_size)
+  const servingSize = isNaN(rawServingSize) || rawServingSize <= 0 ? 100 : rawServingSize
+  const rawUnit = row.serving_size_unit?.trim()
+  const servingUnit = normaliseUnit(rawUnit) ?? rawUnit ?? 'g'
+
+  targetBranded.set(row.fdc_id, {
+    brandOwner: row.brand_owner ?? '',
+    barcode: row.gtin_upc ?? '',
+    servingSize,
+    servingUnit,
+    category,
+  })
+}
+process.stdout.write('\n')
+console.log(`  ${totalBrandedRows.toLocaleString()} total branded rows`)
+console.log(`  ${targetBranded.size.toLocaleString()} accepted (category match)`)
+console.log(`  ${skippedCategory.toLocaleString()} skipped (category filter)`)
+
+if (targetBranded.size === 0) {
+  console.error('No branded products passed the category filter — check ALLOWED_CATEGORY_SUBSTRINGS.')
+  process.exit(1)
+}
+
+// ── Step 3: Stream food.csv to collect descriptions ───────────────────────────
+
+console.log('\nStreaming food.csv for descriptions…')
+const descriptions = new Map<string, string>()
+let totalFoodRows = 0
+
+for await (const row of streamCSVRows(join(dir, 'food.csv'))) {
+  totalFoodRows++
+  if (totalFoodRows % 50000 === 0) {
+    process.stdout.write(`\r  scanned ${totalFoodRows.toLocaleString()} rows…`)
+  }
+  if (targetBranded.has(row.fdc_id)) {
+    descriptions.set(row.fdc_id, row.description)
+  }
+}
+process.stdout.write('\n')
+console.log(`  ${descriptions.size.toLocaleString()} descriptions matched`)
+
+// ── Step 4: Build portions and density maps ───────────────────────────────────
+
+console.log('\nBuilding portions and density maps…')
+const portionsByFood = new Map<string, Measurement[]>()
+const densityByFood = new Map<string, number>()
+
+for (const r of portionRows) {
+  if (!targetBranded.has(r.fdc_id)) continue
+  const amount = parseFloat(r.amount)
+  const gramWeight = parseFloat(r.gram_weight)
+  if (!amount || !gramWeight || isNaN(amount) || isNaN(gramWeight)) continue
+
+  const unitName = measureUnits.get(r.measure_unit_id) ?? r.portion_description
+  if (!unitName || unitName === 'undetermined' || unitName === '') continue
+
+  // Derive density from the first volume portion found
+  const unitLower = unitName.toLowerCase().trim()
+  const mlPerUnit = VOLUME_TO_ML[unitLower]
+  if (mlPerUnit !== undefined && !densityByFood.has(r.fdc_id)) {
+    const mlTotal = mlPerUnit * amount
+    if (mlTotal > 0) {
+      densityByFood.set(r.fdc_id, Math.round((gramWeight / mlTotal) * 10000) / 10000)
+    }
+  }
+
+  // Only store non-standard units as Calibrated Custom Unit Measurements
+  const isStandardUnit = normaliseUnit(unitName) !== null
+  if (!isStandardUnit) {
+    const gramsPerUnit = gramWeight / amount
+    const existing = portionsByFood.get(r.fdc_id) ?? []
+    if (!existing.some(m => m.unit === unitLower)) {
+      existing.push({ unit: unitLower, gramsPerUnit: Math.round(gramsPerUnit * 100) / 100 })
+    }
+    portionsByFood.set(r.fdc_id, existing)
+  }
+}
+console.log(`  ${portionsByFood.size.toLocaleString()} products have portion data`)
+console.log(`  ${densityByFood.size.toLocaleString()} products have density`)
+
+// ── Step 5: Stream food_nutrient.csv ─────────────────────────────────────────
+
+console.log('\nStreaming food_nutrient.csv (this takes a while)…')
+const nutrientByFood = new Map<string, Map<string, number>>()
+const wantedNids = new Set<string>(Object.values(NID))
+let totalNutrientRows = 0
+let keptNutrientRows = 0
+
+for await (const row of streamCSVRows(join(dir, 'food_nutrient.csv'))) {
+  totalNutrientRows++
+  if (totalNutrientRows % 500000 === 0) {
+    process.stdout.write(`\r  scanned ${totalNutrientRows.toLocaleString()} rows, kept ${keptNutrientRows.toLocaleString()}…`)
+  }
+  if (!targetBranded.has(row.fdc_id)) continue
+  if (!wantedNids.has(row.nutrient_id)) continue
+  const amount = parseFloat(row.amount)
+  if (isNaN(amount)) continue
+  keptNutrientRows++
+  if (!nutrientByFood.has(row.fdc_id)) nutrientByFood.set(row.fdc_id, new Map())
+  nutrientByFood.get(row.fdc_id)!.set(row.nutrient_id, amount)
+}
+process.stdout.write('\n')
+console.log(`  ${totalNutrientRows.toLocaleString()} rows scanned, ${keptNutrientRows.toLocaleString()} kept`)
+
+// ── Step 6: Load existing products from DB ────────────────────────────────────
+
+console.log('\nQuerying existing products in database…')
+const allExistingRows = await db
+  .select({ id: products.id, externalId: products.externalId, dateDeleted: products.dateDeleted, slug: products.slug })
+  .from(products)
+
+const existingByExternalId = new Map(
+  allExistingRows
+    .filter(r => r.externalId)
+    .map(r => [r.externalId!, { id: r.id, isDeleted: r.dateDeleted !== null }])
+)
+const takenSlugs = new Set(allExistingRows.map(r => r.slug).filter(Boolean) as string[])
+
+console.log(`  ${allExistingRows.length.toLocaleString()} products already in DB`)
+console.log(`  ${existingByExternalId.size.toLocaleString()} have externalId`)
+
+// ── Step 7: Build insert / update lists ──────────────────────────────────────
+
+type ProductValues = typeof products.$inferInsert
+
+function buildValues(fdcId: string, meta: BrandedMeta): ProductValues {
+  const nids = nutrientByFood.get(fdcId)
+  const get = (id: string) => nids?.get(id) ?? 0
+
+  const rawName = descriptions.get(fdcId) ?? `USDA Branded Food ${fdcId}`
+  const name = rawName.length > 255 ? rawName.slice(0, 252) + '…' : rawName
+  const portions = portionsByFood.get(fdcId) ?? []
+
+  // Scale macros from per-100g to per serving when the serving unit is grams
+  const isGramBased = /^g$/i.test(meta.servingUnit)
+  const scale = isGramBased ? meta.servingSize / 100 : 1
+
+  // slug: leave room for -fdcId suffix (fdcIds up to 8 digits + hyphen = 9 chars)
+  const baseSlug = toSlug(name).slice(0, 245)
+  const slug = takenSlugs.has(baseSlug) ? `${baseSlug}-${fdcId}` : baseSlug
+  takenSlugs.add(slug)
+
+  // Clamp all numeric fields to their DB column limits.
+  // Bad data in the CSV (e.g. absurd bulk serving sizes) is safer to cap than crash.
+  const mac = (v: number) => String(Math.min(Math.round(v * 100) / 100, 99999999.99))  // numeric(10,2)
+  const sod = (v: number) => String(Math.min(Math.round(v * 10)  / 10,  999999999.9))  // numeric(10,1)
+  const srv = (v: number) => String(Math.min(Math.round(v * 100) / 100, 99999999.99))  // numeric(10,2)
+
+  const density = densityByFood.get(fdcId)
+
+  return {
+    name,
+    slug,
+    barcode: meta.barcode ? meta.barcode.slice(0, 50) : null,
+    externalId: fdcId,
+    parentFoodId: null,
+    calories: Math.min(Math.round(get(NID.energy) * scale), 2147483647),
+    protein: mac(get(NID.protein) * scale),
+    carbs:   mac(get(NID.carbs)   * scale),
+    fat:     mac(get(NID.fat)      * scale),
+    fiber:   mac(get(NID.fiber)    * scale),
+    saturatedFat: get(NID.satFat) ? mac(get(NID.satFat) * scale) : null,
+    sugar:   get(NID.sugar)  ? mac(get(NID.sugar)  * scale) : null,
+    sodium:  get(NID.sodium) ? sod(get(NID.sodium) * scale) : null,
+    servingSize: srv(meta.servingSize),
+    servingUnit: meta.servingUnit.slice(0, 50),
+    density: density != null ? String(density) : null,
+    measurements: portions.length
+      ? [{ unit: meta.servingUnit }, ...portions]
+      : [{ unit: meta.servingUnit }],
+    source: 'usda_branded',
+  }
+}
+
+const toInsert: ProductValues[] = []
+const toUpdate: { id: number; values: Partial<ProductValues> }[] = []
+let skippedDeleted = 0
+
+for (const [fdcId, meta] of targetBranded) {
+  const existing = existingByExternalId.get(fdcId)
+  if (existing) {
+    if (existing.isDeleted) { skippedDeleted++; continue }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { slug: _slug, source: _src, parentFoodId: _pid, ...updateFields } = buildValues(fdcId, meta)
+    toUpdate.push({ id: existing.id, values: updateFields })
+  } else {
+    toInsert.push(buildValues(fdcId, meta))
+  }
+}
+
+console.log(`\n  ${toInsert.length.toLocaleString()} to insert`)
+console.log(`  ${toUpdate.length.toLocaleString()} to update`)
+console.log(`  ${skippedDeleted} skipped (soft-deleted)`)
+
+// ── Step 8: Batch insert ──────────────────────────────────────────────────────
+
+let inserted = 0
+if (toInsert.length > 0) {
+  console.log('\nInserting…')
+  for (const batch of chunk(toInsert, INSERT_CHUNK)) {
+    await db.insert(products).values(batch)
+    inserted += batch.length
+    progress('inserted', inserted, toInsert.length)
+  }
+  process.stdout.write('\n')
+}
+
+// ── Step 9: Batch update ──────────────────────────────────────────────────────
+
+let updated = 0
+if (toUpdate.length > 0) {
+  console.log('\nUpdating…')
+  const tasks = toUpdate.map(({ id, values }) => async () => {
+    await db.update(products).set({ ...values, dateUpdated: new Date() }).where(eq(products.id, id))
+    updated++
+    if (updated % UPDATE_CONCURRENCY === 0) progress('updated', updated, toUpdate.length)
+  })
+  await runConcurrently(tasks, UPDATE_CONCURRENCY)
+  progress('updated', updated, toUpdate.length)
+  process.stdout.write('\n')
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log('\n─────────────────────────────────────────')
+console.log(`  Inserted:      ${inserted.toLocaleString()}`)
+console.log(`  Updated:       ${updated.toLocaleString()}`)
+console.log(`  Skipped:       ${skippedDeleted} (soft-deleted)`)
+console.log(`  Category skip: ${skippedCategory.toLocaleString()}`)
+console.log('─────────────────────────────────────────')
+console.log('Done. Run link-product-foods.ts to assign parent Foods.\n')
+
+process.exit(0)


### PR DESCRIPTION
## Summary

- **`scripts/seed-usda-branded.ts`** — streams FDC Full Download CSVs, filters to cooking-relevant `branded_food_category` values, derives density from volume portions, and upserts into the `products` table with `parentFoodId = null`. Clamps all numeric columns to their DB limits to handle bad CSV data. Re-runnable; upserts on `externalId`.

- **`scripts/link-product-foods.ts`** — processes all unlinked products (`parentFoodId IS NULL`, all sources). For each: strips brand prefix + weight suffix from the name, searches `foods` for up to 5 candidates, and asks Claude Haiku to pick the best parent Food or return `"none"`. Skips the LLM call entirely when no candidates are found. Supports `--dry-run`, `--limit`, and `--concurrency`. Re-runnable and incremental.

- **`docs/adr/0019-usda-branded-import-two-pass-ai-linking.md`** — documents the decision to separate import from linking (fast deterministic import + independently rate-limited AI linker), rather than doing both inline.

## Usage

```bash
# 1. Import branded products (parentFoodId = null)
bun --env-file .env.local scripts/seed-usda-branded.ts --dir ./data/usda

# 2. Preview what the linker would do
bun --env-file .env.local scripts/link-product-foods.ts --dry-run --limit 200

# 3. Run the linker
bun --env-file .env.local scripts/link-product-foods.ts --concurrency 10
```

## Test plan

- [ ] Run `seed-usda-branded.ts` against a real FDC Full Download; verify products are inserted with correct macros, density where available, and `parentFoodId = null`
- [ ] Re-run to confirm upsert behaviour (no duplicates, existing rows updated)
- [ ] Run `link-product-foods.ts --dry-run --limit 50` and inspect output for sensible matches
- [ ] Run without `--dry-run` on a small batch; verify `parentFoodId` is set on matched rows
- [ ] Confirm products with no candidate Foods remain `parentFoodId = null` (not errored)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)