### PR TITLE
fix: sanitize recipe HTML isomorphically to fix SSR 500

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,6 @@
         "barcode-detector": "^3.2.0",
         "bcrypt": "^6.0.0",
         "convert-units": "^2.3.4",
-        "dompurify": "^3.4.1",
         "drizzle-orm": "^0.45.2",
         "gray-matter": "^4.0.3",
         "jose": "^6.2.3",
@@ -550,8 +549,6 @@
 
     "@types/sanitize-html": ["@types/sanitize-html@2.16.1", "", { "dependencies": { "htmlparser2": "^10.1" } }, "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA=="],
 
-    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
-
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.47.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.47.0", "@typescript-eslint/type-utils": "8.47.0", "@typescript-eslint/utils": "8.47.0", "@typescript-eslint/visitor-keys": "8.47.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.47.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA=="],
@@ -783,8 +780,6 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
-
-    "dompurify": ["dompurify@3.4.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "barcode-detector": "^3.2.0",
     "bcrypt": "^6.0.0",
     "convert-units": "^2.3.4",
-    "dompurify": "^3.4.1",
     "drizzle-orm": "^0.45.2",
     "gray-matter": "^4.0.3",
     "jose": "^6.2.3",

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { Card } from 'primereact/card'
 import { Checkbox } from 'primereact/checkbox'
-import DOMPurify from 'dompurify'
+import { sanitizeRichText } from '@/lib/sanitize'
 import { toRecipeUrl } from '@/utils/slug'
 import type { Recipe } from '@/types/Recipe'
 import StatusDot from '@/components/StatusLegend/StatusDot'
@@ -47,7 +47,7 @@ export default function RecipeCard({ recipe, selected, onSelect }: RecipeCardPro
         </div>
         <div
           className="card-description"
-          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(recipe.description) }}
+          dangerouslySetInnerHTML={{ __html: sanitizeRichText(recipe.description) }}
         />
         <div className="card-footer">
           <span className="card-meta">

--- a/src/components/RecipeStepBlock/RecipeStepBlock.tsx
+++ b/src/components/RecipeStepBlock/RecipeStepBlock.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import DOMPurify from 'dompurify'
 import { Editor } from 'primereact/editor'
 import { FileUpload, type FileUploadHandlerEvent } from 'primereact/fileupload'
+import { sanitizeRichText } from '@/lib/sanitize'
 import type { RecipeStep } from '@/types/RecipeStep'
 
 interface RecipeStepBlockProps {
@@ -79,7 +79,7 @@ export default function RecipeStepBlock({
       ) : (
         <div
           className="step-content"
-          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(step.content) }}
+          dangerouslySetInnerHTML={{ __html: sanitizeRichText(step.content) }}
         />
       )}
     </div>

--- a/src/lib/sanitize.test.ts
+++ b/src/lib/sanitize.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeRichText } from '@/lib/sanitize'
+
+describe('sanitizeRichText', () => {
+  it('removes disallowed tags', () => {
+    const result = sanitizeRichText('<p>Hello</p><script>alert(1)</script>')
+
+    expect(result).toContain('<p>Hello</p>')
+    expect(result).not.toContain('<script>')
+  })
+
+  it('keeps vercel blob https images', () => {
+    const src = 'https://abc.public.blob.vercel-storage.com/image.png'
+
+    const result = sanitizeRichText(`<p>Image</p><img src="${src}" alt="ok" />`)
+
+    expect(result).toContain(`<img src="${src}" alt="ok" />`)
+  })
+
+  it('removes non-blob images', () => {
+    const result = sanitizeRichText('<img src="https://example.com/image.png" alt="nope" />')
+
+    expect(result).not.toContain('<img')
+  })
+})

--- a/src/views/Recipe/Index.tsx
+++ b/src/views/Recipe/Index.tsx
@@ -4,7 +4,6 @@ import { useState, useRef } from 'react'
 import Link from 'next/link'
 import { Toast } from 'primereact/toast'
 import { Dropdown } from 'primereact/dropdown'
-import DOMPurify from 'dompurify'
 import Autocomplete from '@/components/Autocomplete/Autocomplete'
 import RecipeStepBlock from '@/components/RecipeStepBlock/RecipeStepBlock'
 import { type Recipe } from '@/types/Recipe'
@@ -20,6 +19,7 @@ import {
 import { Editor } from 'primereact/editor'
 import FoodSearch from '@/components/FoodSearch/FoodSearch'
 import { calculateCalories, getAllowedUnits } from "@/utils/unitConversion"
+import { sanitizeRichText } from '@/lib/sanitize'
 import { cuisineOptions, dietaryOptions } from '@/constants/userPreferences'
 import ReviewsTab from '@/views/Recipe/ReviewsTab'
 import PrepareMealDialog from '@/components/PrepareMealDialog/PrepareMealDialog'
@@ -412,7 +412,7 @@ export default function Recipe({ recipe, foods = [], isEditing = false, canEdit 
         ) : (
           <div
             className="recipe-description"
-            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(displayRecipe.description) }}
+            dangerouslySetInnerHTML={{ __html: sanitizeRichText(displayRecipe.description) }}
           />
         )}
 


### PR DESCRIPTION
## What

Recipe detail pages and the `/recipes` list returned **HTTP 500** in dev due to a DOMPurify SSR error:

```
TypeError: {imported module dompurify}.default.sanitize is not a function
```

`import DOMPurify from 'dompurify'` yields an *uninitialized factory* when there's no DOM. The affected components (`RecipeCard`, `RecipeStepBlock`, `Recipe/Index`) are `'use client'`, but they still render once on the server during SSR, where `DOMPurify.sanitize` doesn't exist.

## Fix

Route all three render-time sanitize calls through the existing `sanitizeRichText` helper in [`src/lib/sanitize.ts`](../blob/main/src/lib/sanitize.ts), which is built on `sanitize-html`. It parses HTML with `htmlparser2` and needs **no DOM**, so it runs on both server and client.

- `src/components/RecipeCard/RecipeCard.tsx` — description
- `src/components/RecipeStepBlock/RecipeStepBlock.tsx` — step content
- `src/views/Recipe/Index.tsx` — description
- Removed the now-unused `dompurify` dependency (+ lockfile).

### Why this approach

`isomorphic-dompurify` and the "jsdom window on the server" option both pull heavy jsdom into the production runtime. `sanitizeRichText` was already a production dependency, and reusing it means render-time sanitization now applies the **same Quill allow-list** already used at write time — consistent policy across write/read and server/client.

## Verification

- **Dev:** `/recipes` → 200 (cards render), recipe detail → 200 with description + steps rendering sanitized `<p>` HTML. No browser-console or server sanitize errors.
- **Production:** `bun run build` compiles clean; `bun run start` serves both routes with 200 and zero sanitize errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)