### PR TITLE
perf: stop blocking recipe view render on the full food catalog

### DIFF
--- a/app/recipes/[id]/[slug]/page.tsx
+++ b/app/recipes/[id]/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound, permanentRedirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { getRecipeByShortId, getRecipeSummaryByShortId, isSaved } from '@/lib/recipes'
-import { getFoods } from '@/lib/foods'
 import { getSessionUser } from '@/lib/auth'
 import { toSlug } from '@/utils/slug'
 import RecipeIndex from '@/views/Recipe/Index'
@@ -11,7 +10,9 @@ type Props = { params: Promise<{ id: string; slug: string }> }
 
 export default async function RecipePage({ params }: Props) {
   const { id, slug } = await params
-  const [foods, session, requestHeaders] = await Promise.all([getFoods(), getSessionUser(), headers()])
+  // The food catalog only powers ingredient editing, so it's loaded lazily on the client (see
+  // RecipeIndex) rather than shipped with every — mostly read-only, often anonymous — recipe view.
+  const [session, requestHeaders] = await Promise.all([getSessionUser(), headers()])
 
   // The Signup Wall applies only to Anonymous Visitors; the meter decision is set
   // authoritatively by middleware. Gating a logged-in user is impossible here even
@@ -39,7 +40,6 @@ export default async function RecipePage({ params }: Props) {
       <RecipeViewBeacon shortId={recipe.shortId} />
       <RecipeIndex
         recipe={recipe}
-        foods={foods}
         canEdit={isOwner}
         canSave={canSave}
         initialSaved={initialSaved}

--- a/src/views/Recipe/Index.test.tsx
+++ b/src/views/Recipe/Index.test.tsx
@@ -412,6 +412,19 @@ describe('Recipe View Page', () => {
 
       expect(await screen.findByLabelText('Ingredient 3 name')).toBeInTheDocument()
     })
+
+    it('does not stack a second empty row while an unpicked placeholder exists', async () => {
+      const user = userEvent.setup()
+      renderWithStores(<Recipe recipe={mockRecipe} />)
+
+      await user.click(screen.getByRole('button', { name: /edit/i }))
+      await user.click(screen.getByRole('button', { name: /add ingredient/i }))
+      expect(await screen.findByLabelText('Ingredient 3 name')).toBeInTheDocument()
+
+      // The row is still an unpicked placeholder (food id 0), so a second add is a no-op.
+      await user.click(screen.getByRole('button', { name: /add ingredient/i }))
+      expect(screen.queryByLabelText('Ingredient 4 name')).not.toBeInTheDocument()
+    })
   })
 
   describe('Copy Recipe Functionality', () => {

--- a/src/views/Recipe/Index.test.tsx
+++ b/src/views/Recipe/Index.test.tsx
@@ -401,17 +401,16 @@ describe('Recipe View Page', () => {
       })
     })
 
-    it('does not add ingredient when foods list is empty', async () => {
+    it('adds an ingredient row even when the local food catalog is empty', async () => {
       const user = userEvent.setup()
+      // The catalog now loads lazily, so edit mode can begin before any local foods are present.
+      // FoodSearch is server-backed, so the row can still be added and populated.
       renderWithStores(<Recipe recipe={mockRecipe} />, { foods: [] })
 
       await user.click(screen.getByRole('button', { name: /edit/i }))
       await user.click(screen.getByRole('button', { name: /add ingredient/i }))
 
-      // Should still only have 2 ingredients since no foods available
-      expect(screen.getByLabelText('Ingredient 1 name')).toBeInTheDocument()
-      expect(screen.getByLabelText('Ingredient 2 name')).toBeInTheDocument()
-      expect(screen.queryByLabelText('Ingredient 3 name')).not.toBeInTheDocument()
+      expect(await screen.findByLabelText('Ingredient 3 name')).toBeInTheDocument()
     })
   })
 

--- a/src/views/Recipe/Index.tsx
+++ b/src/views/Recipe/Index.tsx
@@ -55,18 +55,30 @@ export default function Recipe({ recipe, foods = [], isEditing = false, canEdit 
   const [perServing, setPerServing] = useState(true)
   const [activePanel, setActivePanel] = useState<'ingredients' | 'reviews'>('ingredients')
   const stepDebounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  // Tracks whether the lazy catalog fetch has been kicked off. A ref (not `localFoods.length`) so that
+  // FoodSearch appending a picked food to `localFoods` can't re-run the effect and cancel the in-flight
+  // request. Starts "loaded" when a caller already supplied foods.
+  const catalogFetchStartedRef = useRef(foods.length > 0)
 
-  // The food catalog only powers ingredient editing, so fetch it lazily the first time the user is in
-  // edit mode rather than shipping it with every (read-only, often anonymous) recipe view. Skipped
-  // when a caller already provided foods. FoodSearch queries the server per keystroke regardless.
+  // The food catalog only powers ingredient editing, so fetch it lazily the first time the user enters
+  // edit mode rather than shipping it with every (read-only, often anonymous) recipe view. FoodSearch
+  // queries the server per keystroke regardless, so this only warms instant local suggestions.
   useEffect(() => {
-    if (!editMode || localFoods.length > 0) return
+    if (!editMode || catalogFetchStartedRef.current) return
+    catalogFetchStartedRef.current = true
     let cancelled = false
     apiFetchFoods()
-      .then((fetched) => { if (!cancelled && fetched.length > 0) setLocalFoods(fetched) })
-      .catch(() => { /* instant suggestions are best-effort; server search still works */ })
+      .then((fetched) => {
+        if (cancelled || fetched.length === 0) return
+        // Merge rather than replace so a food the user picked while the fetch was in flight survives.
+        setLocalFoods((prev) => {
+          const fetchedIds = new Set(fetched.map((food) => food.id))
+          return [...fetched, ...prev.filter((food) => !fetchedIds.has(food.id))]
+        })
+      })
+      .catch(() => { catalogFetchStartedRef.current = false })
     return () => { cancelled = true }
-  }, [editMode, localFoods.length])
+  }, [editMode])
 
   let publishedText = "Unpublished"
   let isPublished = false
@@ -197,8 +209,10 @@ export default function Recipe({ recipe, foods = [], isEditing = false, canEdit 
       return
     }
 
-    // Check if there's an empty ingredient slot already (prevents adding duplicates)
-    const hasEmptyIngredient = editedRecipe.ingredients.some(ing => !ing.food)
+    // A freshly-added row carries the placeholder Food (id 0) until the user picks one via FoodSearch.
+    // `Ingredient.food` is always set, so detect that sentinel — not a falsy food — to avoid stacking
+    // multiple unpicked rows.
+    const hasEmptyIngredient = editedRecipe.ingredients.some(ing => ing.food.id === 0)
     if (hasEmptyIngredient) {
       return // Don't add another empty ingredient if one already exists
     }

--- a/src/views/Recipe/Index.tsx
+++ b/src/views/Recipe/Index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
 import { Toast } from 'primereact/toast'
 import { Dropdown } from 'primereact/dropdown'
@@ -16,6 +16,7 @@ import {
   apiCreateRecipeStep, apiUpdateRecipeStep, apiDeleteRecipeStep,
   apiReorderRecipeSteps, apiUploadImage,
 } from '@/lib/api/recipes'
+import { apiFetchFoods } from '@/lib/api/foods'
 import { Editor } from 'primereact/editor'
 import FoodSearch from '@/components/FoodSearch/FoodSearch'
 import { calculateCalories, getAllowedUnits } from "@/utils/unitConversion"
@@ -54,6 +55,18 @@ export default function Recipe({ recipe, foods = [], isEditing = false, canEdit 
   const [perServing, setPerServing] = useState(true)
   const [activePanel, setActivePanel] = useState<'ingredients' | 'reviews'>('ingredients')
   const stepDebounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  // The food catalog only powers ingredient editing, so fetch it lazily the first time the user is in
+  // edit mode rather than shipping it with every (read-only, often anonymous) recipe view. Skipped
+  // when a caller already provided foods. FoodSearch queries the server per keystroke regardless.
+  useEffect(() => {
+    if (!editMode || localFoods.length > 0) return
+    let cancelled = false
+    apiFetchFoods()
+      .then((fetched) => { if (!cancelled && fetched.length > 0) setLocalFoods(fetched) })
+      .catch(() => { /* instant suggestions are best-effort; server search still works */ })
+    return () => { cancelled = true }
+  }, [editMode, localFoods.length])
 
   let publishedText = "Unpublished"
   let isPublished = false
@@ -190,29 +203,27 @@ export default function Recipe({ recipe, foods = [], isEditing = false, canEdit 
       return // Don't add another empty ingredient if one already exists
     }
 
-    // Create a placeholder ingredient with the first food
-    if (localFoods.length > 0) {
-      // default to empty values
-      const defaultFood = {
-        id: 0,
-        name: '',
-        calories: 0,
-        protein: 0,
-        carbs: 0,
-        fat: 0,
-        fiber: 0,
-        servingSize: 1,
-        servingUnit: DEFAULT_SERVING_UNIT,
-        measurements: [],
-      }
-      const newIngredient: Ingredient = {
-        food: defaultFood,
-        quantity: defaultFood.servingSize || 1,
-        calories: defaultFood.calories || 0,
-        servingUnit: defaultFood.servingUnit || DEFAULT_SERVING_UNIT,
-      }
-      setEditedRecipe(prev => ({ ...prev, ingredients: [...prev.ingredients, newIngredient] }))
+    // Add an empty placeholder row; its Food is chosen via FoodSearch (server-backed), so this does
+    // not depend on the local catalog being loaded yet.
+    const defaultFood = {
+      id: 0,
+      name: '',
+      calories: 0,
+      protein: 0,
+      carbs: 0,
+      fat: 0,
+      fiber: 0,
+      servingSize: 1,
+      servingUnit: DEFAULT_SERVING_UNIT,
+      measurements: [],
     }
+    const newIngredient: Ingredient = {
+      food: defaultFood,
+      quantity: defaultFood.servingSize || 1,
+      calories: defaultFood.calories || 0,
+      servingUnit: defaultFood.servingUnit || DEFAULT_SERVING_UNIT,
+    }
+    setEditedRecipe(prev => ({ ...prev, ingredients: [...prev.ingredients, newIngredient] }))
   }
 
   function handleIngredientFoodChange(index: number, food: Food) {


### PR DESCRIPTION
## Problem

Every recipe view — including anonymous visitors, gated (signup-wall) traffic, and plain read-only views — awaited `getFoods()` (the entire global food catalog: all rows, all columns, unbounded) in the server component and serialized it into the RSC payload. That catalog is only used for **ingredient editing**, so the vast majority of recipe views paid a large TTFB + payload cost for data they never touch.

## Fix

- **page** (`app/recipes/[id]/[slug]/page.tsx`): drop the eager `getFoods()`; no longer pass `foods` to `RecipeIndex`. Viewers load nothing extra.
- **view** (`src/views/Recipe/Index.tsx`): fetch the catalog lazily via `apiFetchFoods()` the first time the user is actually in **edit mode**, off the render path. Skipped when a caller already supplies `foods`. `FoodSearch` queries the server per keystroke regardless, so this only powers instant pre-debounce suggestions.
- Remove the `localFoods.length > 0` gate on **Add Ingredient**: the placeholder row uses a hardcoded empty food (not the local catalog), and `FoodSearch` is server-backed, so the gate blocked nothing meaningful — and with lazy loading it would have briefly no-op'd the button right after entering edit mode. Now the add flow works immediately.

## Impact

- Read-only / anonymous / gated recipe views: no longer fetch or ship the food catalog at all.
- Editors: catalog loads lazily on entering edit mode, non-blocking.

## Testing

- Full unit suite green; recipe view tests (50) pass, including an updated test asserting an ingredient row can be added even when the local catalog is empty.
- `tsc --noEmit` and `eslint` clean.

Not verified in a running browser (the page needs a live DB + session, not reproducible in my environment); behavior rests on the tests above.

> Split out from #111 review discussion — same root cause as the shopping-list perf fix there, but an independent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)