### PR TITLE
feat(shopping-list): Shopping Trip Completion → Pantry (#103)

### DIFF
--- a/app/api/shopping-list/complete/route.test.ts
+++ b/app/api/shopping-list/complete/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+import { POST } from './route'
+import { completeShoppingTrip } from '@/lib/shoppingList'
+import { getSessionUser } from '@/lib/auth'
+
+vi.mock('@/lib/shoppingList', () => ({
+  completeShoppingTrip: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getSessionUser: vi.fn(),
+}))
+
+function completeRequest(body: unknown) {
+  return new Request('http://localhost/api/shopping-list/complete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/shopping-list/complete', () => {
+  it('returns 401 when there is no session', async () => {
+    (getSessionUser as Mock).mockResolvedValue(null)
+
+    const res = await POST(completeRequest({ keepUnbought: true }))
+
+    expect(res.status).toBe(401)
+    expect(completeShoppingTrip).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when keepUnbought is missing or not a boolean', async () => {
+    (getSessionUser as Mock).mockResolvedValue({ userId: 42, username: 'alice' })
+
+    const res = await POST(completeRequest({ keepUnbought: 'yes' }))
+
+    expect(res.status).toBe(400)
+    expect(completeShoppingTrip).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a non-object body', async () => {
+    (getSessionUser as Mock).mockResolvedValue({ userId: 42, username: 'alice' })
+
+    const res = await POST(completeRequest([1, 2, 3]))
+
+    expect(res.status).toBe(400)
+    expect(completeShoppingTrip).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the user has no active list', async () => {
+    (getSessionUser as Mock).mockResolvedValue({ userId: 42, username: 'alice' });
+    (completeShoppingTrip as Mock).mockResolvedValue(null)
+
+    const res = await POST(completeRequest({ keepUnbought: false }))
+
+    expect(res.status).toBe(404)
+    expect(completeShoppingTrip).toHaveBeenCalledWith(42, { keepUnbought: false })
+  })
+
+  it('completes the trip and returns the result, scoped to the session user', async () => {
+    (getSessionUser as Mock).mockResolvedValue({ userId: 42, username: 'alice' })
+    const result = { pantryItemsCreated: 2, keptCount: 1, droppedCount: 0, items: [] };
+    (completeShoppingTrip as Mock).mockResolvedValue(result)
+
+    const res = await POST(completeRequest({ keepUnbought: true }))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(result)
+    expect(completeShoppingTrip).toHaveBeenCalledWith(42, { keepUnbought: true })
+  })
+})

--- a/app/api/shopping-list/complete/route.ts
+++ b/app/api/shopping-list/complete/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { getSessionUser } from '@/lib/auth'
+import { taskRunner } from '@/lib/TaskRunner'
+import { completeShoppingTrip } from '@/lib/shoppingList'
+
+// Shopping Trip Completion (see CONTEXT.md): archive the active list, transfer bought Food/Product
+// lines to the Pantry, and either keep or drop the still-unbought lines as one batch. `keepUnbought`
+// is the answer to the single leftover prompt; the client sends `false` outright when nothing is left.
+export async function POST(request: Request) {
+  const user = await getSessionUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  let raw: unknown
+  try {
+    raw = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+  const body = raw as { keepUnbought?: unknown }
+
+  if (typeof body.keepUnbought !== 'boolean') {
+    return NextResponse.json({ error: 'keepUnbought must be a boolean' }, { status: 400 })
+  }
+
+  const result = await taskRunner.run(() => completeShoppingTrip(user.userId, { keepUnbought: body.keepUnbought as boolean }))
+  if (!result) return NextResponse.json({ error: 'No active shopping list' }, { status: 404 })
+
+  return NextResponse.json(result)
+}

--- a/drizzle/0030_solid_darwin.sql
+++ b/drizzle/0030_solid_darwin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pantry_items" ADD COLUMN "shopping_list_item_id" integer;--> statement-breakpoint
+ALTER TABLE "pantry_items" ADD CONSTRAINT "pantry_items_shopping_list_item_id_shopping_list_items_id_fk" FOREIGN KEY ("shopping_list_item_id") REFERENCES "public"."shopping_list_items"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/meta/0030_snapshot.json
+++ b/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,1941 @@
+{
+  "id": "35215a44-ea4c-4454-82f4-4a945363ad97",
+  "prevId": "c9372a60-df53-4c68-863a-789d31399aa1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_feedback": {
+      "name": "account_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "account_closure_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.foods": {
+      "name": "foods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein": {
+          "name": "protein",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "fat": {
+          "name": "fat",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measurements": {
+          "name": "measurements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "density": {
+          "name": "density",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saturated_fat": {
+          "name": "saturated_fat",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sodium": {
+          "name": "sodium",
+          "type": "numeric(10, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "food_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "date_updated": {
+          "name": "date_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_deleted": {
+          "name": "date_deleted",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "foods_slug_unique": {
+          "name": "foods_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredients": {
+      "name": "ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "date_updated": {
+          "name": "date_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_deleted": {
+          "name": "date_deleted",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ingredients_recipe_id_recipes_id_fk": {
+          "name": "ingredients_recipe_id_recipes_id_fk",
+          "tableFrom": "ingredients",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingredients_food_id_foods_id_fk": {
+          "name": "ingredients_food_id_foods_id_fk",
+          "tableFrom": "ingredients",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.login_attempts": {
+      "name": "login_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "successful": {
+          "name": "successful",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "login_attempts_user_id_users_id_fk": {
+          "name": "login_attempts_user_id_users_id_fk",
+          "tableFrom": "login_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_account_unique": {
+          "name": "oauth_accounts_provider_account_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pantry_items": {
+      "name": "pantry_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'food'"
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_name_snapshot": {
+          "name": "recipe_name_snapshot",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shopping_list_item_id": {
+          "name": "shopping_list_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_size_amount": {
+          "name": "original_size_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_size_unit": {
+          "name": "original_size_unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_size_amount": {
+          "name": "current_size_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_size_unit": {
+          "name": "current_size_unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_date": {
+          "name": "added_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "frozen_date": {
+          "name": "frozen_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_deleted": {
+          "name": "date_deleted",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pantry_items_user_id_users_id_fk": {
+          "name": "pantry_items_user_id_users_id_fk",
+          "tableFrom": "pantry_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_items_food_id_foods_id_fk": {
+          "name": "pantry_items_food_id_foods_id_fk",
+          "tableFrom": "pantry_items",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_items_product_id_products_id_fk": {
+          "name": "pantry_items_product_id_products_id_fk",
+          "tableFrom": "pantry_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_items_recipe_id_recipes_id_fk": {
+          "name": "pantry_items_recipe_id_recipes_id_fk",
+          "tableFrom": "pantry_items",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pantry_items_shopping_list_item_id_shopping_list_items_id_fk": {
+          "name": "pantry_items_shopping_list_item_id_shopping_list_items_id_fk",
+          "tableFrom": "pantry_items",
+          "tableTo": "shopping_list_items",
+          "columnsFrom": [
+            "shopping_list_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_food_id": {
+          "name": "parent_food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein": {
+          "name": "protein",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "fat": {
+          "name": "fat",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measurements": {
+          "name": "measurements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "density": {
+          "name": "density",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saturated_fat": {
+          "name": "saturated_fat",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sodium": {
+          "name": "sodium",
+          "type": "numeric(10, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "product_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "date_updated": {
+          "name": "date_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_deleted": {
+          "name": "date_deleted",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "products_parent_food_id_foods_id_fk": {
+          "name": "products_parent_food_id_foods_id_fk",
+          "tableFrom": "products",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "parent_food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_steps": {
+      "name": "recipe_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "date_deleted": {
+          "name": "date_deleted",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipe_steps_recipe_id_deleted_position_idx": {
+          "name": "recipe_steps_recipe_id_deleted_position_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_steps_recipe_id_recipes_id_fk": {
+          "name": "recipe_steps_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_steps",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_id": {
+          "name": "short_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meal": {
+          "name": "meal",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prep_time": {
+          "name": "prep_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cook_time": {
+          "name": "cook_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_time": {
+          "name": "total_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cuisine_type": {
+          "name": "cuisine_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_tags": {
+          "name": "dietary_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "serves": {
+          "name": "serves",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nutrition_complete": {
+          "name": "nutrition_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "date_published": {
+          "name": "date_published",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_deleted": {
+          "name": "date_deleted",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipes_user_id_users_id_fk": {
+          "name": "recipes_user_id_users_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipes_short_id_unique": {
+          "name": "recipes_short_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_likes_review_id_idx": {
+          "name": "review_likes_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_likes_user_review_unique": {
+          "name": "review_likes_user_review_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "review_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_reports": {
+      "name": "review_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "review_report_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_reports_review_id_idx": {
+          "name": "review_reports_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_reports_date_added_idx": {
+          "name": "review_reports_date_added_idx",
+          "columns": [
+            {
+              "expression": "date_added",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reports_user_id_users_id_fk": {
+          "name": "review_reports_user_id_users_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "review_reports_review_id_reviews_id_fk": {
+          "name": "review_reports_review_id_reviews_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_reports_user_review_unique": {
+          "name": "review_reports_user_review_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "review_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_updated": {
+          "name": "date_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reviews_recipe_id_idx": {
+          "name": "reviews_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_recipe_id_recipes_id_fk": {
+          "name": "reviews_recipe_id_recipes_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_recipe_unique": {
+          "name": "reviews_user_recipe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recipe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_recipes": {
+      "name": "saved_recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_saved": {
+          "name": "date_saved",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_deleted": {
+          "name": "date_deleted",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_recipes_user_id_users_id_fk": {
+          "name": "saved_recipes_user_id_users_id_fk",
+          "tableFrom": "saved_recipes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_recipes_recipe_id_recipes_id_fk": {
+          "name": "saved_recipes_recipe_id_recipes_id_fk",
+          "tableFrom": "saved_recipes",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_recipes_user_recipe_unique": {
+          "name": "saved_recipes_user_recipe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recipe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_list_items": {
+      "name": "shopping_list_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shopping_list_id": {
+          "name": "shopping_list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "shopping_list_item_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'food'"
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "shopping_list_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'to_buy'"
+        },
+        "line_price": {
+          "name": "line_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shopping_list_items_shopping_list_id_idx": {
+          "name": "shopping_list_items_shopping_list_id_idx",
+          "columns": [
+            {
+              "expression": "shopping_list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_list_items_shopping_list_id_shopping_lists_id_fk": {
+          "name": "shopping_list_items_shopping_list_id_shopping_lists_id_fk",
+          "tableFrom": "shopping_list_items",
+          "tableTo": "shopping_lists",
+          "columnsFrom": [
+            "shopping_list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shopping_list_items_food_id_foods_id_fk": {
+          "name": "shopping_list_items_food_id_foods_id_fk",
+          "tableFrom": "shopping_list_items",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shopping_list_items_product_id_products_id_fk": {
+          "name": "shopping_list_items_product_id_products_id_fk",
+          "tableFrom": "shopping_list_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_lists": {
+      "name": "shopping_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "shopping_list_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shopping_lists_user_active_unique": {
+          "name": "shopping_lists_user_active_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"shopping_lists\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_lists_user_id_users_id_fk": {
+          "name": "shopping_lists_user_id_users_id_fk",
+          "tableFrom": "shopping_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cuisine_preferences": {
+          "name": "cuisine_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "dietary_restrictions": {
+          "name": "dietary_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_changed_at": {
+          "name": "password_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketing_email_opt_in": {
+          "name": "marketing_email_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recipe_suggestion_frequency": {
+          "name": "recipe_suggestion_frequency",
+          "type": "recipe_suggestion_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "pantry_expiration_frequency": {
+          "name": "pantry_expiration_frequency",
+          "type": "pantry_expiration_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "enable_shopping_list_pricing_collection": {
+          "name": "enable_shopping_list_pricing_collection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "date_deleted": {
+          "name": "date_deleted",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivation_warning_email_sent_at": {
+          "name": "deactivation_warning_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_closure_action": {
+      "name": "account_closure_action",
+      "schema": "public",
+      "values": [
+        "deactivated",
+        "deleted"
+      ]
+    },
+    "public.food_source": {
+      "name": "food_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "open_food_facts",
+        "usda"
+      ]
+    },
+    "public.pantry_expiration_frequency": {
+      "name": "pantry_expiration_frequency",
+      "schema": "public",
+      "values": [
+        "never",
+        "daily",
+        "weekly"
+      ]
+    },
+    "public.product_source": {
+      "name": "product_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "open_food_facts",
+        "usda_branded"
+      ]
+    },
+    "public.recipe_suggestion_frequency": {
+      "name": "recipe_suggestion_frequency",
+      "schema": "public",
+      "values": [
+        "never",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.review_report_reason": {
+      "name": "review_report_reason",
+      "schema": "public",
+      "values": [
+        "spam",
+        "offensive_language",
+        "harassment",
+        "off_topic"
+      ]
+    },
+    "public.shopping_list_item_source_type": {
+      "name": "shopping_list_item_source_type",
+      "schema": "public",
+      "values": [
+        "food",
+        "product",
+        "freeform"
+      ]
+    },
+    "public.shopping_list_item_status": {
+      "name": "shopping_list_item_status",
+      "schema": "public",
+      "values": [
+        "to_buy",
+        "bought",
+        "unavailable"
+      ]
+    },
+    "public.shopping_list_status": {
+      "name": "shopping_list_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1783564075312,
       "tag": "0029_cheerful_weapon_omega",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1783601398624,
+      "tag": "0030_solid_darwin",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -129,6 +129,11 @@ export const pantryItems = pgTable('pantry_items', {
   recipeId: integer('recipe_id')
     .references(() => recipes.id, { onDelete: 'set null' }),
   recipeNameSnapshot: varchar('recipe_name_snapshot', { length: 255 }),
+  // Provenance back to the Shopping List Item that produced this Pantry Item on Shopping Trip
+  // Completion (see CONTEXT.md). Null for items created any other way (manual add, Prepared Meal).
+  // `set null` so archiving/removing the source line never deletes the resulting stock.
+  shoppingListItemId: integer('shopping_list_item_id')
+    .references(() => shoppingListItems.id, { onDelete: 'set null' }),
   expirationDate: timestamp('expiration_date'),
   originalSizeAmount: numeric('original_size_amount', { precision: 10, scale: 2 }).notNull(),
   originalSizeUnit: varchar('original_size_unit', { length: 50 }),

--- a/src/lib/api/shoppingList.ts
+++ b/src/lib/api/shoppingList.ts
@@ -1,4 +1,4 @@
-import type { ShoppingListItem, ShoppingListItemStatus } from '@/types/ShoppingList'
+import type { ShoppingListItem, ShoppingListItemStatus, ShoppingTripCompletion } from '@/types/ShoppingList'
 
 type RawShoppingListItem = Omit<ShoppingListItem, 'addedDate' | 'expirationDate'> & {
   addedDate: string
@@ -121,18 +121,10 @@ export async function apiSplitShoppingListItem(
   return raw.map(parseShoppingListItem)
 }
 
-// What the server reports after finishing a shopping trip: how many Pantry Items were created, how the
-// leftover lines were handled, and the new active list's items (the kept lines, or empty when dropped).
-export type CompleteShoppingTripResult = {
-  pantryItemsCreated: number
-  keptCount: number
-  droppedCount: number
-  items: ShoppingListItem[]
-}
-
 // Finish the shopping trip: archive the active list, transfer bought Food/Product lines to the Pantry,
 // and keep or drop the still-unbought lines as one batch. `keepUnbought` answers the leftover prompt.
-export async function apiCompleteShoppingTrip(keepUnbought: boolean): Promise<CompleteShoppingTripResult> {
+// Returns the ShoppingTripCompletion the server reports, with its items parsed to domain objects.
+export async function apiCompleteShoppingTrip(keepUnbought: boolean): Promise<ShoppingTripCompletion> {
   const res = await fetch('/api/shopping-list/complete', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -140,6 +132,6 @@ export async function apiCompleteShoppingTrip(keepUnbought: boolean): Promise<Co
   })
 
   if (!res.ok) throw new Error('Failed to complete shopping trip')
-  const raw: Omit<CompleteShoppingTripResult, 'items'> & { items: RawShoppingListItem[] } = await res.json()
+  const raw: Omit<ShoppingTripCompletion, 'items'> & { items: RawShoppingListItem[] } = await res.json()
   return { ...raw, items: raw.items.map(parseShoppingListItem) }
 }

--- a/src/lib/api/shoppingList.ts
+++ b/src/lib/api/shoppingList.ts
@@ -120,3 +120,26 @@ export async function apiSplitShoppingListItem(
   const raw: RawShoppingListItem[] = await res.json()
   return raw.map(parseShoppingListItem)
 }
+
+// What the server reports after finishing a shopping trip: how many Pantry Items were created, how the
+// leftover lines were handled, and the new active list's items (the kept lines, or empty when dropped).
+export type CompleteShoppingTripResult = {
+  pantryItemsCreated: number
+  keptCount: number
+  droppedCount: number
+  items: ShoppingListItem[]
+}
+
+// Finish the shopping trip: archive the active list, transfer bought Food/Product lines to the Pantry,
+// and keep or drop the still-unbought lines as one batch. `keepUnbought` answers the leftover prompt.
+export async function apiCompleteShoppingTrip(keepUnbought: boolean): Promise<CompleteShoppingTripResult> {
+  const res = await fetch('/api/shopping-list/complete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ keepUnbought }),
+  })
+
+  if (!res.ok) throw new Error('Failed to complete shopping trip')
+  const raw: Omit<CompleteShoppingTripResult, 'items'> & { items: RawShoppingListItem[] } = await res.json()
+  return { ...raw, items: raw.items.map(parseShoppingListItem) }
+}

--- a/src/lib/pantry.ts
+++ b/src/lib/pantry.ts
@@ -75,6 +75,7 @@ function mapPantryItem(
     recipeId: row.recipeId ?? null,
     recipeNameSnapshot: row.recipeNameSnapshot ?? null,
     recipeShortId: recipeShortId ?? null,
+    shoppingListItemId: row.shoppingListItemId ?? null,
     expirationDate,
     originalSize: {
       size: Number(row.originalSizeAmount),

--- a/src/lib/shoppingList.integration.test.ts
+++ b/src/lib/shoppingList.integration.test.ts
@@ -531,6 +531,24 @@ describe('shopping list data layer (integration)', () => {
     expect(productPantry.shopping_list_item_id).toBe(productLine.id)
   })
 
+  it('does not transfer a bought line whose product was soft-deleted since it was added', async () => {
+    const user = await createTestUser('tripSoftDel')
+    const product = await createTestProduct('TestShopping TripSoftDeleted')
+
+    const line = await createShoppingListProductItem({ userId: user.id, productId: product.id, amount: 1, unit: 'box' })
+    await updateShoppingListItemStatus(line.id, user.id, 'bought')
+
+    // Soft-delete the product after it was bought but before completion. Such a line is already hidden
+    // from the shopping list and its resulting pantry item would be hidden too, so it must not transfer.
+    await pool.query(`UPDATE products SET date_deleted = now() WHERE id = $1`, [product.id])
+
+    const result = await completeShoppingTrip(user.id, { keepUnbought: false })
+    expect(result?.pantryItemsCreated).toBe(0)
+
+    const pantry = await pool.query(`SELECT id FROM pantry_items WHERE user_id = $1`, [user.id])
+    expect(pantry.rowCount).toBe(0)
+  })
+
   it('does not transfer bought freeform lines to the pantry on completion', async () => {
     const user = await createTestUser('tripB')
 

--- a/src/lib/shoppingList.integration.test.ts
+++ b/src/lib/shoppingList.integration.test.ts
@@ -609,6 +609,30 @@ describe('shopping list data layer (integration)', () => {
     expect(active.rows[0].count).toBe(0)
   })
 
+  it('adds a new line onto a fresh active list after a completion archived the previous one', async () => {
+    const user = await createTestUser('tripReadd')
+    const food = await createTestFood('TestShopping TripReadd')
+
+    const firstLine = await createShoppingListFoodItem({ userId: user.id, foodId: food.id, amount: 1, unit: 'g' })
+    await updateShoppingListItemStatus(firstLine.id, user.id, 'bought')
+    await completeShoppingTrip(user.id, { keepUnbought: false })
+
+    // Adding after completion must resolve (and, here, create) a fresh active list — never write onto
+    // the archived one. This is the sequential form of the archived-under-lock retry guard.
+    const secondLine = await createShoppingListFoodItem({ userId: user.id, foodId: food.id, amount: 2, unit: 'g' })
+    expect(secondLine.id).not.toBe(firstLine.id)
+
+    const active = await getShoppingListItems(user.id)
+    expect(active.map((item) => item.id)).toEqual([secondLine.id])
+
+    // The new line sits on an active list distinct from the archived one holding the first line.
+    const listRows = await pool.query(
+      `SELECT sl.status FROM shopping_list_items sli JOIN shopping_lists sl ON sl.id = sli.shopping_list_id WHERE sli.id = $1`,
+      [secondLine.id]
+    )
+    expect(listRows.rows[0].status).toBe('active')
+  })
+
   it('returns null when completing a trip with no active list', async () => {
     const user = await createTestUser('tripE')
     // Create then archive the only active list, leaving none.

--- a/src/lib/shoppingList.integration.test.ts
+++ b/src/lib/shoppingList.integration.test.ts
@@ -4,6 +4,7 @@ import { createFood } from './foods'
 import { createProduct } from './products'
 import { signUp } from './users'
 import {
+  completeShoppingTrip,
   createShoppingListFoodItem,
   createShoppingListFreeformItem,
   createShoppingListProductItem,
@@ -20,6 +21,9 @@ const connectionString = process.env.DATABASE_URL || `postgresql://${process.env
 const pool = new Pool({ connectionString })
 
 async function cleanup() {
+  // Trip Completion turns bought lines into pantry items; clear those first so the FK back to the
+  // shopping line (onDelete set null) and the food/product deletes below have nothing dangling.
+  await pool.query(`DELETE FROM pantry_items WHERE user_id IN (SELECT id FROM users WHERE username LIKE 'testshopping%')`)
   await pool.query(`DELETE FROM shopping_list_items WHERE shopping_list_id IN (SELECT id FROM shopping_lists WHERE user_id IN (SELECT id FROM users WHERE username LIKE 'testshopping%'))`)
   await pool.query(`DELETE FROM shopping_lists WHERE user_id IN (SELECT id FROM users WHERE username LIKE 'testshopping%')`)
   await pool.query(`DELETE FROM products WHERE name LIKE 'TestShopping%'`)
@@ -477,5 +481,123 @@ describe('shopping list data layer (integration)', () => {
     const items = await getShoppingListItems(owner.id)
     expect(items).toHaveLength(1)
     expect(items[0].amount).toBe(2)
+  })
+
+  it('completes a trip: bought food/product lines become pantry items with carried size/expiration and provenance', async () => {
+    const user = await createTestUser('tripA')
+    const food = await createTestFood('TestShopping TripFood')
+    const product = await createTestProduct('TestShopping TripProduct')
+
+    const foodLine = await createShoppingListFoodItem({ userId: user.id, foodId: food.id, amount: 2, unit: 'oz' })
+    const productLine = await createShoppingListProductItem({ userId: user.id, productId: product.id, amount: 1, unit: 'box' })
+
+    const expiration = new Date('2026-09-01T00:00:00.000Z')
+    // The bought food line carries a price (not copied to the pantry) and an expiration (carried).
+    await updateShoppingListItemDetails(foodLine.id, user.id, { linePrice: 5, expirationDate: expiration })
+    await updateShoppingListItemStatus(foodLine.id, user.id, 'bought')
+    await updateShoppingListItemStatus(productLine.id, user.id, 'bought')
+
+    const result = await completeShoppingTrip(user.id, { keepUnbought: false })
+    expect(result).not.toBeNull()
+    expect(result?.pantryItemsCreated).toBe(2)
+    // Nothing left unbought, so the fresh active list is empty.
+    expect(result?.items).toHaveLength(0)
+
+    // The old list is archived.
+    const lists = await pool.query(`SELECT status FROM shopping_lists WHERE user_id = $1 ORDER BY id`, [user.id])
+    expect(lists.rows.some((row) => row.status === 'archived')).toBe(true)
+
+    // One pantry item per bought line, sizes/expiration/provenance carried; Line Price never copied.
+    const pantry = await pool.query(
+      `SELECT source_type, food_id, product_id, original_size_amount, original_size_unit, current_size_amount, current_size_unit, expiration_date, shopping_list_item_id
+         FROM pantry_items WHERE user_id = $1 ORDER BY id`,
+      [user.id]
+    )
+    expect(pantry.rowCount).toBe(2)
+
+    const foodPantry = pantry.rows.find((row) => row.food_id === food.id)
+    expect(foodPantry.source_type).toBe('food')
+    expect(Number(foodPantry.original_size_amount)).toBe(2)
+    expect(foodPantry.original_size_unit).toBe('oz')
+    expect(Number(foodPantry.current_size_amount)).toBe(2)
+    expect(foodPantry.current_size_unit).toBe('oz')
+    expect(new Date(foodPantry.expiration_date).getTime()).toBe(expiration.getTime())
+    expect(foodPantry.shopping_list_item_id).toBe(foodLine.id)
+
+    const productPantry = pantry.rows.find((row) => row.product_id === product.id)
+    expect(productPantry.source_type).toBe('product')
+    expect(Number(productPantry.original_size_amount)).toBe(1)
+    expect(productPantry.original_size_unit).toBe('box')
+    expect(productPantry.shopping_list_item_id).toBe(productLine.id)
+  })
+
+  it('does not transfer bought freeform lines to the pantry on completion', async () => {
+    const user = await createTestUser('tripB')
+
+    const freeform = await createShoppingListFreeformItem({ userId: user.id, name: 'TestShopping TripBags', amount: 3, unit: 'box' })
+    await updateShoppingListItemStatus(freeform.id, user.id, 'bought')
+
+    const result = await completeShoppingTrip(user.id, { keepUnbought: false })
+    expect(result?.pantryItemsCreated).toBe(0)
+
+    const pantry = await pool.query(`SELECT id FROM pantry_items WHERE user_id = $1`, [user.id])
+    expect(pantry.rowCount).toBe(0)
+  })
+
+  it('keeps still-unbought lines on a fresh active list when the batch prompt is kept', async () => {
+    const user = await createTestUser('tripC')
+    const bought = await createTestFood('TestShopping TripKeptBought')
+    const toBuy = await createTestFood('TestShopping TripKeptToBuy')
+    const unavailable = await createTestFood('TestShopping TripKeptUnavailable')
+
+    const boughtLine = await createShoppingListFoodItem({ userId: user.id, foodId: bought.id, amount: 1, unit: 'g' })
+    const toBuyLine = await createShoppingListFoodItem({ userId: user.id, foodId: toBuy.id, amount: 1, unit: 'g' })
+    const unavailableLine = await createShoppingListFoodItem({ userId: user.id, foodId: unavailable.id, amount: 1, unit: 'g' })
+    await updateShoppingListItemStatus(boughtLine.id, user.id, 'bought')
+    await updateShoppingListItemStatus(unavailableLine.id, user.id, 'unavailable')
+
+    const result = await completeShoppingTrip(user.id, { keepUnbought: true })
+    expect(result?.pantryItemsCreated).toBe(1)
+    // Both the to_buy and the unavailable line are kept together on the new active list.
+    expect(result?.keptCount).toBe(2)
+    expect(result?.droppedCount).toBe(0)
+
+    const activeItems = await getShoppingListItems(user.id)
+    expect(activeItems.map((item) => item.id).sort()).toEqual([toBuyLine.id, unavailableLine.id].sort())
+    // Exactly one active list exists after completion.
+    const active = await pool.query(`SELECT COUNT(*)::int AS count FROM shopping_lists WHERE user_id = $1 AND status = 'active'`, [user.id])
+    expect(active.rows[0].count).toBe(1)
+  })
+
+  it('drops still-unbought lines with the archive when the batch prompt is not kept', async () => {
+    const user = await createTestUser('tripD')
+    const bought = await createTestFood('TestShopping TripDropBought')
+    const toBuy = await createTestFood('TestShopping TripDropToBuy')
+
+    const boughtLine = await createShoppingListFoodItem({ userId: user.id, foodId: bought.id, amount: 1, unit: 'g' })
+    const toBuyLine = await createShoppingListFoodItem({ userId: user.id, foodId: toBuy.id, amount: 1, unit: 'g' })
+    await updateShoppingListItemStatus(boughtLine.id, user.id, 'bought')
+
+    const result = await completeShoppingTrip(user.id, { keepUnbought: false })
+    expect(result?.keptCount).toBe(0)
+    expect(result?.droppedCount).toBe(1)
+    // Dropped lines are discarded with the archive: the fresh active list is empty.
+    expect(result?.items).toHaveLength(0)
+
+    // The dropped line stays on the archived list (not deleted) — just no longer on an active list.
+    const stillThere = await pool.query(`SELECT id FROM shopping_list_items WHERE id = $1`, [toBuyLine.id])
+    expect(stillThere.rowCount).toBe(1)
+    const active = await pool.query(`SELECT COUNT(*)::int AS count FROM shopping_lists WHERE user_id = $1 AND status = 'active'`, [user.id])
+    expect(active.rows[0].count).toBe(0)
+  })
+
+  it('returns null when completing a trip with no active list', async () => {
+    const user = await createTestUser('tripE')
+    // Create then archive the only active list, leaving none.
+    await getOrCreateActiveShoppingList(user.id)
+    await completeShoppingTrip(user.id, { keepUnbought: false })
+
+    const result = await completeShoppingTrip(user.id, { keepUnbought: false })
+    expect(result).toBeNull()
   })
 })

--- a/src/lib/shoppingList.ts
+++ b/src/lib/shoppingList.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm'
 import { db } from '@/db'
-import { foods, products, shoppingListItems, shoppingLists } from '@/db/schema'
+import { foods, pantryItems, products, shoppingListItems, shoppingLists } from '@/db/schema'
 import { getFoodById } from '@/lib/foods'
 import { getProductById } from '@/lib/products'
 import { EACH_UNIT } from '@/utils/unitConversion'
@@ -655,4 +655,100 @@ export async function createShoppingListFreeformItem(data: CreateShoppingListFre
     amount: data.amount,
     unit,
   })
+}
+
+// The outcome of a Shopping Trip Completion: how many Pantry Items were created, and how the still-
+// unbought lines were handled (kept onto a fresh active list, or dropped with the archive). `items` is
+// the new active list's contents afterwards — the kept lines when keeping, otherwise empty.
+export type CompleteShoppingTripResult = {
+  pantryItemsCreated: number
+  keptCount: number
+  droppedCount: number
+  items: ShoppingListItem[]
+}
+
+// Finish a shopping trip (see CONTEXT.md "Shopping Trip Completion"). Archives the user's active list,
+// turns every *bought* Food/Product line into exactly one Pantry Item (originalSize = the line's
+// quantity + unit, currentSize equal, expiration carried when set, and a provenance FK back to the
+// source line), and never transfers freeform lines. Still-unbought lines (`to_buy` and `unavailable`
+// together) are handled as one group: when `keepUnbought` they move onto a fresh active list, otherwise
+// they are discarded with the archive. The Line Price stays on the archived line — it is never copied
+// to the Pantry. The whole thing runs in one transaction that locks the active list row, so a
+// concurrent completion (or add) can't race it. Returns null when the user has no active list (→ 404).
+export async function completeShoppingTrip(
+  userId: number,
+  options: { keepUnbought: boolean },
+): Promise<CompleteShoppingTripResult | null> {
+  const outcome = await db.transaction(async (tx) => {
+    // Lock the active list so a concurrent completion/add serialises behind this one.
+    const [list] = await tx
+      .select({ id: shoppingLists.id })
+      .from(shoppingLists)
+      .where(and(eq(shoppingLists.userId, userId), eq(shoppingLists.status, 'active')))
+      .for('update')
+
+    if (!list) return null
+
+    const rows = await tx
+      .select()
+      .from(shoppingListItems)
+      .where(eq(shoppingListItems.shoppingListId, list.id))
+
+    // Archive the current list before touching anything else. Doing it first frees the partial unique
+    // "one active list per user" index so the fresh active list below can be inserted.
+    await tx.update(shoppingLists).set({ status: 'archived' }).where(eq(shoppingLists.id, list.id))
+
+    // Bought Food/Product lines each become one Pantry Item; bought freeform lines never transfer.
+    const transferable = rows.filter(
+      (row) => row.status === 'bought' && (row.sourceType === 'food' || row.sourceType === 'product'),
+    )
+    if (transferable.length > 0) {
+      await tx.insert(pantryItems).values(transferable.map((row) => ({
+        userId,
+        sourceType: row.sourceType,
+        foodId: row.foodId,
+        productId: row.productId,
+        // Carried when the line recorded one; null otherwise. Line Price is deliberately not copied.
+        expirationDate: row.expirationDate,
+        // amount is a numeric column, already a string on read — pass it straight through.
+        originalSizeAmount: row.amount,
+        originalSizeUnit: row.unit,
+        currentSizeAmount: row.amount,
+        currentSizeUnit: row.unit,
+        shoppingListItemId: row.id,
+      })))
+    }
+
+    // `to_buy` and `unavailable` are not distinguished here — both are "still unbought" and handled as
+    // one batch. Kept lines move to a new active list; dropped lines stay on the archive.
+    const unbought = rows.filter((row) => row.status === 'to_buy' || row.status === 'unavailable')
+
+    let keptCount = 0
+    if (options.keepUnbought && unbought.length > 0) {
+      const [newList] = await tx
+        .insert(shoppingLists)
+        .values({ userId, status: 'active' })
+        .returning({ id: shoppingLists.id })
+
+      await tx
+        .update(shoppingListItems)
+        .set({ shoppingListId: newList.id })
+        .where(inArray(shoppingListItems.id, unbought.map((row) => row.id)))
+
+      keptCount = unbought.length
+    }
+
+    return {
+      pantryItemsCreated: transferable.length,
+      keptCount,
+      droppedCount: options.keepUnbought ? 0 : unbought.length,
+    }
+  })
+
+  if (outcome === null) return null
+
+  // Re-read the active list's contents: the kept lines (now on the fresh list) when keeping, else empty
+  // (no active list exists until one is lazily created on the next visit).
+  const items = await getShoppingListItems(userId)
+  return { ...outcome, items }
 }

--- a/src/lib/shoppingList.ts
+++ b/src/lib/shoppingList.ts
@@ -249,73 +249,94 @@ type ResolvedNewItem = {
   unit: string | null
 }
 
+// A concurrent Shopping Trip Completion can archive the active list between the moment an add resolves
+// it and the moment the add locks its row. Cap how many times the add re-resolves the (new) active list
+// before giving up — a completion creates at most one fresh active list, so a couple of retries covers
+// any realistic interleaving; the extra headroom guards against a pathological double-completion.
+const INSERT_ACTIVE_LIST_MAX_ATTEMPTS = 3
+
 // Insert a new line, or merge into an existing open (to_buy) line with the same source identity and
 // unit. Merging keeps a different unit — or an already-bought line — separate. The whole
 // read-then-write runs in a transaction that locks the parent list row, so two concurrent adds of the
-// same source + unit cannot both miss the existing line and insert duplicates.
+// same source + unit cannot both miss the existing line and insert duplicates. Because a concurrent
+// Trip Completion archives the list while holding that same row lock, we re-check the status once we
+// hold the lock: if the list was archived out from under us we re-resolve the now-current active list
+// and retry, so a line can never land on an archived list.
 async function insertOrMergeItem(userId: number, values: ResolvedNewItem): Promise<ShoppingListItem> {
-  const shoppingList = await getOrCreateActiveShoppingList(userId)
-
   // A line's identity is its source: the Food, the Product, or the freeform name. Freeform names
   // match case-insensitively, so "Trash bags" and "trash bags" merge (the existing line keeps its
   // original casing). A Food and Product that share a name never merge, because sourceType — and thus
-  // the matched column — differs.
+  // the matched column — differs. Independent of the list, so it is built once outside the retry loop.
   const identityMatch: SQL =
     values.sourceType === 'food' ? eq(shoppingListItems.foodId, values.foodId as number)
       : values.sourceType === 'product' ? eq(shoppingListItems.productId, values.productId as number)
         : sql`lower(${shoppingListItems.name}) = lower(${values.name as string})`
 
-  const itemId = await db.transaction(async (tx) => {
-    await tx
-      .select({ id: shoppingLists.id })
-      .from(shoppingLists)
-      .where(eq(shoppingLists.id, shoppingList.id))
-      .for('update')
+  for (let attempt = 0; attempt < INSERT_ACTIVE_LIST_MAX_ATTEMPTS; attempt++) {
+    const shoppingList = await getOrCreateActiveShoppingList(userId)
 
-    const [existing] = await tx
-      .select()
-      .from(shoppingListItems)
-      .where(and(
-        eq(shoppingListItems.shoppingListId, shoppingList.id),
-        eq(shoppingListItems.sourceType, values.sourceType),
-        identityMatch,
-        values.unit === null ? isNull(shoppingListItems.unit) : eq(shoppingListItems.unit, values.unit),
-        eq(shoppingListItems.status, 'to_buy'),
-      ))
+    const itemId = await db.transaction(async (tx) => {
+      const [locked] = await tx
+        .select({ id: shoppingLists.id, status: shoppingLists.status })
+        .from(shoppingLists)
+        .where(eq(shoppingLists.id, shoppingList.id))
+        .for('update')
 
-    if (existing) {
-      const mergedAmount = Number(existing.amount) + values.amount
-      // Each add is individually in range, but their sum can still exceed the column ceiling.
-      assertAmountInRange(mergedAmount)
-      const [updated] = await tx
-        .update(shoppingListItems)
-        // numeric(10,2): round the merged total to 2 decimals so we never persist a
-        // floating-point artifact like "0.30000000000000004".
-        .set({ amount: mergedAmount.toFixed(2) })
-        .where(eq(shoppingListItems.id, existing.id))
+      // Archived (or gone) after we resolved it — a concurrent Trip Completion won the race. Signal a
+      // retry rather than writing onto a stale list; the next attempt re-resolves the fresh active list.
+      if (!locked || locked.status !== 'active') return null
+
+      const [existing] = await tx
+        .select()
+        .from(shoppingListItems)
+        .where(and(
+          eq(shoppingListItems.shoppingListId, shoppingList.id),
+          eq(shoppingListItems.sourceType, values.sourceType),
+          identityMatch,
+          values.unit === null ? isNull(shoppingListItems.unit) : eq(shoppingListItems.unit, values.unit),
+          eq(shoppingListItems.status, 'to_buy'),
+        ))
+
+      if (existing) {
+        const mergedAmount = Number(existing.amount) + values.amount
+        // Each add is individually in range, but their sum can still exceed the column ceiling.
+        assertAmountInRange(mergedAmount)
+        const [updated] = await tx
+          .update(shoppingListItems)
+          // numeric(10,2): round the merged total to 2 decimals so we never persist a
+          // floating-point artifact like "0.30000000000000004".
+          .set({ amount: mergedAmount.toFixed(2) })
+          .where(eq(shoppingListItems.id, existing.id))
+          .returning()
+        return updated.id
+      }
+
+      const [row] = await tx
+        .insert(shoppingListItems)
+        .values({
+          shoppingListId: shoppingList.id,
+          sourceType: values.sourceType,
+          foodId: values.foodId,
+          productId: values.productId,
+          name: values.name,
+          amount: values.amount.toFixed(2),
+          unit: values.unit,
+          status: 'to_buy',
+        })
         .returning()
-      return updated.id
-    }
+      return row.id
+    })
 
-    const [row] = await tx
-      .insert(shoppingListItems)
-      .values({
-        shoppingListId: shoppingList.id,
-        sourceType: values.sourceType,
-        foodId: values.foodId,
-        productId: values.productId,
-        name: values.name,
-        amount: values.amount.toFixed(2),
-        unit: values.unit,
-        status: 'to_buy',
-      })
-      .returning()
-    return row.id
-  })
+    // The list was archived mid-add — re-resolve the current active list and try again.
+    if (itemId === null) continue
 
-  const item = await getShoppingListItemById(itemId, userId)
-  if (!item) throw new Error('Failed to create shopping list item')
-  return item
+    const item = await getShoppingListItemById(itemId, userId)
+    if (!item) throw new Error('Failed to create shopping list item')
+    return item
+  }
+
+  // Every attempt found the list archived under the lock (a pathological run of concurrent completions).
+  throw new Error('Failed to create shopping list item')
 }
 
 export type CreateShoppingListFoodItemData = {

--- a/src/lib/shoppingList.ts
+++ b/src/lib/shoppingList.ts
@@ -7,7 +7,7 @@ import { EACH_UNIT } from '@/utils/unitConversion'
 import { round2 } from '@/utils/number'
 import type { Food, Measurement } from '@/types/Food'
 import type { Product, ProductSource } from '@/types/Product'
-import type { ShoppingList, ShoppingListItem, ShoppingListItemSourceType } from '@/types/ShoppingList'
+import type { ShoppingList, ShoppingListItem, ShoppingListItemSourceType, ShoppingTripCompletion } from '@/types/ShoppingList'
 
 const POSTGRES_UNIQUE_VIOLATION = '23505'
 
@@ -657,16 +657,6 @@ export async function createShoppingListFreeformItem(data: CreateShoppingListFre
   })
 }
 
-// The outcome of a Shopping Trip Completion: how many Pantry Items were created, and how the still-
-// unbought lines were handled (kept onto a fresh active list, or dropped with the archive). `items` is
-// the new active list's contents afterwards — the kept lines when keeping, otherwise empty.
-export type CompleteShoppingTripResult = {
-  pantryItemsCreated: number
-  keptCount: number
-  droppedCount: number
-  items: ShoppingListItem[]
-}
-
 // Finish a shopping trip (see CONTEXT.md "Shopping Trip Completion"). Archives the user's active list,
 // turns every *bought* Food/Product line into exactly one Pantry Item (originalSize = the line's
 // quantity + unit, currentSize equal, expiration carried when set, and a provenance FK back to the
@@ -678,7 +668,7 @@ export type CompleteShoppingTripResult = {
 export async function completeShoppingTrip(
   userId: number,
   options: { keepUnbought: boolean },
-): Promise<CompleteShoppingTripResult | null> {
+): Promise<ShoppingTripCompletion | null> {
   const outcome = await db.transaction(async (tx) => {
     // Lock the active list so a concurrent completion/add serialises behind this one.
     const [list] = await tx
@@ -689,39 +679,51 @@ export async function completeShoppingTrip(
 
     if (!list) return null
 
+    // Join the source Food/Product so a line pointing at a soft-deleted one can be recognised. Freeform
+    // lines join neither. `.select()` returns the joined rows as { shopping_list_items, foods, products }.
     const rows = await tx
       .select()
       .from(shoppingListItems)
+      .leftJoin(foods, eq(shoppingListItems.foodId, foods.id))
+      .leftJoin(products, eq(shoppingListItems.productId, products.id))
       .where(eq(shoppingListItems.shoppingListId, list.id))
 
     // Archive the current list before touching anything else. Doing it first frees the partial unique
     // "one active list per user" index so the fresh active list below can be inserted.
     await tx.update(shoppingLists).set({ status: 'archived' }).where(eq(shoppingLists.id, list.id))
 
-    // Bought Food/Product lines each become one Pantry Item; bought freeform lines never transfer.
-    const transferable = rows.filter(
-      (row) => row.status === 'bought' && (row.sourceType === 'food' || row.sourceType === 'product'),
-    )
+    // Bought Food/Product lines with a live source each become one Pantry Item; bought freeform lines
+    // never transfer. A line whose Food/Product was soft-deleted since it was added is skipped too:
+    // getShoppingListItems already hides such a line and getPantryItems would hide the resulting item,
+    // so transferring it would only orphan invisible stock.
+    const transferable = rows.filter(({ shopping_list_items: line, foods: food, products: product }) => {
+      if (line.status !== 'bought') return false
+      if (line.sourceType === 'food') return food != null && food.dateDeleted == null
+      if (line.sourceType === 'product') return product != null && product.dateDeleted == null
+      return false
+    })
     if (transferable.length > 0) {
-      await tx.insert(pantryItems).values(transferable.map((row) => ({
+      await tx.insert(pantryItems).values(transferable.map(({ shopping_list_items: line }) => ({
         userId,
-        sourceType: row.sourceType,
-        foodId: row.foodId,
-        productId: row.productId,
+        sourceType: line.sourceType,
+        foodId: line.foodId,
+        productId: line.productId,
         // Carried when the line recorded one; null otherwise. Line Price is deliberately not copied.
-        expirationDate: row.expirationDate,
+        expirationDate: line.expirationDate,
         // amount is a numeric column, already a string on read — pass it straight through.
-        originalSizeAmount: row.amount,
-        originalSizeUnit: row.unit,
-        currentSizeAmount: row.amount,
-        currentSizeUnit: row.unit,
-        shoppingListItemId: row.id,
+        originalSizeAmount: line.amount,
+        originalSizeUnit: line.unit,
+        currentSizeAmount: line.amount,
+        currentSizeUnit: line.unit,
+        shoppingListItemId: line.id,
       })))
     }
 
     // `to_buy` and `unavailable` are not distinguished here — both are "still unbought" and handled as
     // one batch. Kept lines move to a new active list; dropped lines stay on the archive.
-    const unbought = rows.filter((row) => row.status === 'to_buy' || row.status === 'unavailable')
+    const unbought = rows
+      .map(({ shopping_list_items: line }) => line)
+      .filter((line) => line.status === 'to_buy' || line.status === 'unavailable')
 
     let keptCount = 0
     if (options.keepUnbought && unbought.length > 0) {

--- a/src/types/PantryItem.ts
+++ b/src/types/PantryItem.ts
@@ -16,6 +16,7 @@ export type PantryItem = {
   recipeId?: number | null            // set when sourceType === 'recipe'
   recipeNameSnapshot?: string | null  // set when sourceType === 'recipe'
   recipeShortId?: string | null       // non-null when the recipe still exists (not deleted)
+  shoppingListItemId?: number | null   // provenance: the Shopping List Item this came from, if any
   expirationDate: Date | null
   originalSize: ServingSize
   currentSize: ServingSize

--- a/src/types/ShoppingList.ts
+++ b/src/types/ShoppingList.ts
@@ -31,3 +31,14 @@ export type ShoppingListItem = {
   expirationDate: Date | null
   addedDate: Date
 }
+
+// The outcome of a Shopping Trip Completion, shared by the data layer (which produces it) and the API
+// client (which parses it): how many Pantry Items were created, how the still-unbought lines were
+// handled (kept onto a fresh active list, or dropped with the archive), and the new active list's
+// contents afterwards — the kept lines when keeping, otherwise empty.
+export type ShoppingTripCompletion = {
+  pantryItemsCreated: number
+  keptCount: number
+  droppedCount: number
+  items: ShoppingListItem[]
+}

--- a/src/views/ShoppingList/Index.test.tsx
+++ b/src/views/ShoppingList/Index.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/lib/api/shoppingList', () => ({
   apiUpdateShoppingListItemStatus: vi.fn(),
   apiUpdateShoppingListItemDetails: vi.fn(),
   apiSplitShoppingListItem: vi.fn(),
+  apiCompleteShoppingTrip: vi.fn(),
 }))
 
 vi.mock('@/lib/api/foods', () => ({
@@ -64,7 +65,7 @@ vi.mock('@/components/ProductSearch/ProductSearch', () => ({
   ),
 }))
 
-import { apiCreateShoppingListItem, apiDeleteShoppingListItem, apiSplitShoppingListItem, apiUpdateShoppingListItemDetails, apiUpdateShoppingListItemStatus } from '@/lib/api/shoppingList'
+import { apiCompleteShoppingTrip, apiCreateShoppingListItem, apiDeleteShoppingListItem, apiSplitShoppingListItem, apiUpdateShoppingListItemDetails, apiUpdateShoppingListItemStatus } from '@/lib/api/shoppingList'
 import { apiFetchFoods } from '@/lib/api/foods'
 import { apiUpdateShoppingPreferences } from '@/lib/api/users'
 
@@ -1062,5 +1063,112 @@ describe('ShoppingListView — price & expiration', () => {
     expect(await within(dialog).findByRole('alert')).toHaveTextContent(/failed to save/i)
     // The failed save left the stored price untouched.
     expect(useShoppingListStore.getState().items[0].linePrice).toBe(5)
+  })
+})
+
+describe('ShoppingListView — Shopping Trip Completion', () => {
+  beforeEach(() => {
+    resetFoodStore()
+    resetShoppingListStore()
+    vi.clearAllMocks()
+  })
+
+  it('finishes without a prompt when no lines remain unbought', async () => {
+    const user = userEvent.setup()
+    vi.mocked(apiCompleteShoppingTrip).mockResolvedValue({ pantryItemsCreated: 1, keptCount: 0, droppedCount: 0, items: [] })
+
+    render(
+      <ShoppingListView
+        initialFoods={mockFoods}
+        initialItems={[makeItem({ id: 1, status: 'bought' })]}
+      />,
+    )
+    await screen.findByRole('listbox', { name: 'Shopping list items' })
+
+    await user.click(screen.getByRole('button', { name: /done shopping/i }))
+
+    // No leftovers, so it completes straight away (keepUnbought = false) with no prompt.
+    await waitFor(() => expect(apiCompleteShoppingTrip).toHaveBeenCalledWith(false))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // The store is swapped to the server's fresh (empty) list, and a confirmation is shown.
+    expect(useShoppingListStore.getState().items).toHaveLength(0)
+    expect(await screen.findByText(/1 item added to your pantry/i)).toBeInTheDocument()
+  })
+
+  it('prompts for leftovers and keeps them onto the new active list', async () => {
+    const user = userEvent.setup()
+    const keptLine = makeItem({ id: 2, food: mockFoods[1], amount: 1, unit: 'cup', status: 'to_buy' })
+    vi.mocked(apiCompleteShoppingTrip).mockResolvedValue({ pantryItemsCreated: 1, keptCount: 1, droppedCount: 0, items: [keptLine] })
+
+    render(
+      <ShoppingListView
+        initialFoods={mockFoods}
+        initialItems={[
+          makeItem({ id: 1, food: mockFoods[0], status: 'bought' }),
+          keptLine,
+        ]}
+      />,
+    )
+    await screen.findByRole('listbox', { name: 'Shopping list items' })
+
+    await user.click(screen.getByRole('button', { name: /done shopping/i }))
+
+    // One line is still unbought, so the batch prompt appears.
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(/you still have 1 item on your list/i)).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: /keep for next time/i }))
+
+    await waitFor(() => expect(apiCompleteShoppingTrip).toHaveBeenCalledWith(true))
+    // The store now shows only the kept line the server returned.
+    await waitFor(() => expect(useShoppingListStore.getState().items.map((i) => i.id)).toEqual([2]))
+  })
+
+  it('drops the leftovers when the user chooses drop', async () => {
+    const user = userEvent.setup()
+    vi.mocked(apiCompleteShoppingTrip).mockResolvedValue({ pantryItemsCreated: 1, keptCount: 0, droppedCount: 1, items: [] })
+
+    render(
+      <ShoppingListView
+        initialFoods={mockFoods}
+        initialItems={[
+          makeItem({ id: 1, food: mockFoods[0], status: 'bought' }),
+          makeItem({ id: 2, food: mockFoods[1], amount: 1, unit: 'cup', status: 'to_buy' }),
+        ]}
+      />,
+    )
+    await screen.findByRole('listbox', { name: 'Shopping list items' })
+
+    await user.click(screen.getByRole('button', { name: /done shopping/i }))
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: /drop them/i }))
+
+    await waitFor(() => expect(apiCompleteShoppingTrip).toHaveBeenCalledWith(false))
+    await waitFor(() => expect(useShoppingListStore.getState().items).toHaveLength(0))
+  })
+
+  it('keeps the prompt open and shows an error when completion fails', async () => {
+    const user = userEvent.setup()
+    vi.mocked(apiCompleteShoppingTrip).mockRejectedValue(new Error('nope'))
+
+    render(
+      <ShoppingListView
+        initialFoods={mockFoods}
+        initialItems={[
+          makeItem({ id: 1, food: mockFoods[0], status: 'bought' }),
+          makeItem({ id: 2, food: mockFoods[1], amount: 1, unit: 'cup', status: 'to_buy' }),
+        ]}
+      />,
+    )
+    await screen.findByRole('listbox', { name: 'Shopping list items' })
+
+    await user.click(screen.getByRole('button', { name: /done shopping/i }))
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: /keep for next time/i }))
+
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent(/failed to finish shopping/i)
+    // The prompt stays open and the lines are left in place.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(useShoppingListStore.getState().items).toHaveLength(2)
   })
 })

--- a/src/views/ShoppingList/Index.tsx
+++ b/src/views/ShoppingList/Index.tsx
@@ -8,6 +8,7 @@ import ProductSearch from '@/components/ProductSearch/ProductSearch'
 import { useFoodStore } from '@/stores/food'
 import { useShoppingListStore } from '@/stores/shoppingList'
 import {
+  apiCompleteShoppingTrip,
   apiCreateShoppingListItem,
   apiDeleteShoppingListItem,
   apiSplitShoppingListItem,
@@ -527,6 +528,60 @@ function ItemDetailsDialog({
   )
 }
 
+// The single batch prompt shown at Shopping Trip Completion when lines remain unbought (`to_buy` and
+// `unavailable` together — the two are not distinguished here). Keep moves them onto a fresh active
+// list; Drop discards them with the archive. Only mounted while `count > 0`; when nothing is left the
+// trip completes without a prompt.
+function CompleteTripDialog({
+  count,
+  saving,
+  error,
+  onKeep,
+  onDrop,
+  onCancel,
+}: {
+  count: number
+  saving: boolean
+  error: string | null
+  onKeep: () => void
+  onDrop: () => void
+  onCancel: () => void
+}) {
+  const footer = (
+    <div className="dialog-footer">
+      <button type="button" className="ghost-button" onClick={onCancel} disabled={saving}>
+        Cancel
+      </button>
+      <button type="button" className="ghost-button" onClick={onDrop} disabled={saving}>
+        Drop them
+      </button>
+      {/* Keep is the default (see CONTEXT.md). */}
+      <button type="button" className="primary-button" onClick={onKeep} disabled={saving} autoFocus>
+        {saving ? 'Finishing…' : 'Keep for next time'}
+      </button>
+    </div>
+  )
+
+  return (
+    <Modal
+      header="Finish shopping"
+      visible
+      onHide={onCancel}
+      footer={footer}
+      className="complete-trip-dialog"
+      style={{ width: 'min(420px, 92vw)' }}
+    >
+      <p className="complete-trip-message">
+        You still have {count} item{count !== 1 ? 's' : ''} on your list — keep {count !== 1 ? 'them' : 'it'} for next time?
+      </p>
+      <p className="complete-trip-note">
+        Bought items move to your pantry either way.
+      </p>
+      {error && <p className="item-details-error" role="alert">{error}</p>}
+    </Modal>
+  )
+}
+
 export default function ShoppingListView({
   initialFoods,
   initialItems,
@@ -570,6 +625,13 @@ export default function ShoppingListView({
   // The user's "collect price & expiration" preference, held locally so the modal checkbox and the
   // inline "enable" link feel instant. Persisted optimistically; rolled back if the PATCH fails.
   const [collectionEnabled, setCollectionEnabled] = useState(pricingCollectionEnabled)
+
+  // Shopping Trip Completion state: the leftover batch prompt's visibility, the in-flight flag while the
+  // completion request runs, its own error banner, and the post-trip confirmation shown once it lands.
+  const [showCompletePrompt, setShowCompletePrompt] = useState(false)
+  const [completing, setCompleting] = useState(false)
+  const [completeError, setCompleteError] = useState<string | null>(null)
+  const [tripSummary, setTripSummary] = useState<string | null>(null)
 
   async function updateCollectionEnabled(next: boolean) {
     if (next === collectionEnabled) return
@@ -786,6 +848,52 @@ export default function ShoppingListView({
     }
   }
 
+  // Lines still unbought at completion: `to_buy` and `unavailable` together, since the batch prompt
+  // does not distinguish them. Drives whether finishing needs the keep/drop prompt at all.
+  const unboughtItems = useMemo(
+    () => items.filter((item) => item.status === 'to_buy' || item.status === 'unavailable'),
+    [items],
+  )
+
+  // Archive the active list and transfer bought lines to the pantry. `keepUnbought` answers the leftover
+  // prompt; the direct (no-leftover) path passes false. On success swap the store to the server's new
+  // active list (the kept lines, or empty) and show a confirmation. `fromPrompt` routes the error banner
+  // to the open dialog vs. the main add-item banner.
+  async function completeTrip(keepUnbought: boolean, fromPrompt: boolean) {
+    setCompleting(true)
+    setCompleteError(null)
+    setSaveError(null)
+    try {
+      const result = await apiCompleteShoppingTrip(keepUnbought)
+      setItems(result.items)
+      setShowCompletePrompt(false)
+      const created = result.pantryItemsCreated
+      setTripSummary(`Shopping trip complete — ${created} item${created !== 1 ? 's' : ''} added to your pantry.`)
+    } catch {
+      if (fromPrompt) setCompleteError('Failed to finish shopping. Please try again.')
+      else setSaveError('Failed to finish shopping. Please try again.')
+    } finally {
+      setCompleting(false)
+    }
+  }
+
+  // "Done shopping": prompt for the leftovers when any remain, otherwise finish straight away.
+  function handleDoneShopping() {
+    setTripSummary(null)
+    if (unboughtItems.length > 0) {
+      setCompleteError(null)
+      setShowCompletePrompt(true)
+    } else {
+      void completeTrip(false, false)
+    }
+  }
+
+  function handleCancelComplete() {
+    if (completing) return
+    setShowCompletePrompt(false)
+    setCompleteError(null)
+  }
+
   // The Listbox's selection is a live view of which lines are `bought`, derived from status rather than
   // held as separate state — so an optimistic status flip (or its rollback) re-renders the selection.
   const boughtItems = useMemo(() => items.filter((item) => item.status === 'bought'), [items])
@@ -808,15 +916,26 @@ export default function ShoppingListView({
       <div className="shopping-list-content">
         <header className="shopping-list-header">
           <h1>Shopping List</h1>
-          <button
-            type="button"
-            className="share-button"
-            onClick={handleShare}
-            disabled={items.length === 0}
-          >
-            <i className={`pi ${copied ? 'pi-check' : 'pi-share-alt'}`} aria-hidden="true" />
-            {copied ? 'Copied!' : 'Share'}
-          </button>
+          <div className="shopping-list-header-actions">
+            <button
+              type="button"
+              className="share-button"
+              onClick={handleShare}
+              disabled={items.length === 0}
+            >
+              <i className={`pi ${copied ? 'pi-check' : 'pi-share-alt'}`} aria-hidden="true" />
+              {copied ? 'Copied!' : 'Share'}
+            </button>
+            <button
+              type="button"
+              className="done-shopping-button"
+              onClick={handleDoneShopping}
+              disabled={items.length === 0 || completing}
+            >
+              <i className="pi pi-check-circle" aria-hidden="true" />
+              {completing && !showCompletePrompt ? 'Finishing…' : 'Done shopping'}
+            </button>
+          </div>
         </header>
 
         <div className="shopping-list-panel">
@@ -943,6 +1062,12 @@ export default function ShoppingListView({
             </div>
           )}
 
+          {tripSummary && (
+            <div className="trip-summary" role="status">
+              {tripSummary}
+            </div>
+          )}
+
           {!collectionEnabled && (
             <p className="collection-off-hint">
               <em>
@@ -997,6 +1122,17 @@ export default function ShoppingListView({
         onHide={handleCloseDetails}
         onSave={handleSaveDetails}
       />
+
+      {showCompletePrompt && (
+        <CompleteTripDialog
+          count={unboughtItems.length}
+          saving={completing}
+          error={completeError}
+          onKeep={() => completeTrip(true, true)}
+          onDrop={() => completeTrip(false, true)}
+          onCancel={handleCancelComplete}
+        />
+      )}
     </div>
   )
 }

--- a/src/views/ShoppingList/Index.tsx
+++ b/src/views/ShoppingList/Index.tsx
@@ -880,6 +880,7 @@ export default function ShoppingListView({
   // "Done shopping": prompt for the leftovers when any remain, otherwise finish straight away.
   function handleDoneShopping() {
     setTripSummary(null)
+    setSaveError(null)
     if (unboughtItems.length > 0) {
       setCompleteError(null)
       setShowCompletePrompt(true)

--- a/src/views/ShoppingList/shoppingList.scss
+++ b/src/views/ShoppingList/shoppingList.scss
@@ -31,6 +31,45 @@
     padding-top: 12px;
     border-top: 1px solid var(--vscode-border);
   }
+  // Groups the title-row actions (Share + Done shopping) so they wrap together on narrow screens.
+  .shopping-list-header-actions {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: 8px;
+  }
+
+  // Primary title-row action: finishes the trip, archives the list, and sends bought lines to the pantry.
+  .done-shopping-button {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #ffffff;
+    background: var(--vscode-accent);
+    border: 1px solid var(--vscode-accent);
+    box-shadow: 0 4px 12px var(--accent-glow);
+    cursor: pointer;
+
+    .pi {
+      font-size: 14px;
+    }
+
+    &:hover:not(:disabled) {
+      filter: brightness(1.05);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+  }
+
   // Secondary, ghost-style action beside the title: copies the list to the clipboard.
   .share-button {
     flex: 0 0 auto;
@@ -211,6 +250,17 @@
     background: var(--accent-hover);
     color: var(--vscode-text);
     font-size: 13px;
+  }
+
+  // Confirmation shown after a Shopping Trip Completion (e.g. "3 items added to your pantry").
+  .trip-summary {
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--vscode-accent);
+    background: var(--accent-hover);
+    color: var(--vscode-text);
+    font-size: 13px;
+    font-weight: 600;
   }
 
   .shopping-list-empty {
@@ -709,5 +759,18 @@
       opacity: 0.5;
       cursor: not-allowed;
     }
+  }
+
+  // The leftover keep/drop batch prompt at Shopping Trip Completion.
+  .complete-trip-message {
+    margin: 0 0 6px;
+    font-size: 15px;
+    color: var(--vscode-text);
+  }
+
+  .complete-trip-note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--vscode-muted);
   }
 }


### PR DESCRIPTION
Closes #103.

## What this does

Adds a **"Done shopping"** action that archives the active Shopping List and transfers bought stock into the Pantry, per the CONTEXT.md "Shopping Trip Completion" definition.

## Changes

- **Schema / migration `0030`**: `pantry_items` gains a nullable `shopping_list_item_id` FK (`onDelete: set null`) — provenance back to the Shopping List Item that produced the stock. Null for items created any other way.
- **`completeShoppingTrip()`** (`src/lib/shoppingList.ts`), in one transaction that locks the active list:
  - archives the active list
  - each **bought** Food/Product line → exactly one Pantry Item (`originalSize`/`currentSize` = the line's quantity + unit, expiration carried when set, provenance FK set)
  - **freeform** lines never transfer; **Line Price is never copied** to the Pantry
  - still-unbought lines (`to_buy` + `unavailable`, not distinguished) are handled as one batch: **keep** moves them onto a fresh active list, **drop** discards them with the archive
- **API**: `POST /api/shopping-list/complete` (`{ keepUnbought: boolean }`) + `apiCompleteShoppingTrip` client wrapper.
- **UI**: "Done shopping" button in the header, a single keep/drop leftover prompt (only shown when lines remain), and a post-trip confirmation banner.
- **Provenance read-through**: `PantryItem.shoppingListItemId` surfaced in the type + mapper.

## Acceptance criteria

- [x] `pantry_items` gains a nullable `shoppingListItemId` FK (`onDelete: set null`)
- [x] "Done shopping" archives the active list
- [x] Each bought Food/Product line creates one Pantry Item 1:1 with correct size, carried expiration, and provenance FK
- [x] Freeform lines do not transfer
- [x] A single batch prompt keeps or drops all remaining unbought lines; kept lines move to a new active list
- [x] Line Price is not copied onto pantry items
- [x] Tests cover transfer, freeform exclusion, and keep/drop leftovers

## Testing

- Integration tests: transfer (size/expiration/provenance carried, price not copied), freeform exclusion, keep leftovers, drop leftovers, no-active-list → null. (Run in CI against Postgres.)
- Unit: `POST /api/shopping-list/complete` route + `ShoppingListView` completion flow (no-prompt finish, keep, drop, error).
- `tsc --noEmit`, ESLint, and the full 835-test unit suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)